### PR TITLE
Allow specifying the location for the branch number in the branch name template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,10 @@ These arguments can be used with any subcommand:
 - `-T, --target`: Remote target branch (default: "main")
 - `--hyperlinks/--no-hyperlinks`: Enable/disable hyperlink support (default: enabled)
 - `-V, --verbose`: Enable verbose output from Git subcommands (default: false)
-- `--branch-name-template`: Template for generated branch names (default: "$USERNAME/stack")
+- `--branch-name-template`: Template for generated branch names (default: "$USERNAME/stack"). The following variables are supported:
+   - `$USERNAME`: The username of the current user
+   - `$BRANCH`: The current branch name
+   - `$ID`: The location for the ID of the branch. The ID is determined by the order of creation of the branches. If `$ID` is not found in the template, the template will be appended with `/$ID`.
 
 ### Subcommands
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,83 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from stack_pr.cli import (
+    get_branch_id,
+    generate_branch_name,
+    get_taken_branch_ids,
+    get_gh_username,
+    generate_available_branch_name,
+)
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def username():
+    return get_gh_username()
+
+
+@pytest.mark.parametrize(
+    "template,branch_name,expected",
+    [
+        ("feature-$ID-desc", "feature-123-desc", "123"),
+        ("$USERNAME/stack/$ID", "{username}/stack/99", "99"),
+        ("$USERNAME/stack/$ID", "refs/remote/origin/{username}/stack/99", "99"),
+    ],
+)
+def test_get_branch_id(username, template, branch_name, expected):
+    branch_name = branch_name.format(username=username)
+    assert get_branch_id(template, branch_name) == expected
+
+
+@pytest.mark.parametrize(
+    "template,branch_name",
+    [
+        ("feature/$ID/desc", "feature/abc/desc"),
+        ("feature/$ID/desc", "wrong/format"),
+        ("$USERNAME/stack/$ID", "{username}/main/99"),
+    ],
+)
+def test_get_branch_id_no_match(username, template, branch_name):
+    branch_name = branch_name.format(username=username)
+    assert get_branch_id(template, branch_name) is None
+
+
+def test_generate_branch_name():
+    template = "feature/$ID/description"
+    assert generate_branch_name(template, "123") == "feature/123/description"
+
+
+def test_get_taken_branch_ids():
+    template = "User/stack/$ID"
+    refs = [
+        "refs/remotes/origin/User/stack/104",
+        "refs/remotes/origin/User/stack/105",
+        "refs/remotes/origin/User/stack/134",
+    ]
+    assert get_taken_branch_ids(refs, template) == [104, 105, 134]
+    refs = ["User/stack/104", "User/stack/105", "User/stack/134"]
+    assert get_taken_branch_ids(refs, template) == [104, 105, 134]
+    refs = ["User/stack/104", "AAAA/stack/105", "User/stack/134", "User/stack/bbb"]
+    assert get_taken_branch_ids(refs, template) == [104, 134]
+
+
+def test_generate_available_branch_name():
+    template = "User/stack/$ID"
+    refs = [
+        "refs/remotes/origin/User/stack/104",
+        "refs/remotes/origin/User/stack/105",
+        "refs/remotes/origin/User/stack/134",
+    ]
+    assert generate_available_branch_name(refs, template) == "User/stack/135"
+    refs = []
+    assert generate_available_branch_name(refs, template) == "User/stack/1"
+    template = "User-stack-$ID"
+    refs = [
+        "refs/remotes/origin/User-stack-104",
+        "refs/remotes/origin/User-stack-105",
+        "refs/remotes/origin/User-stack-134",
+    ]
+    assert generate_available_branch_name(refs, template) == "User-stack-135"


### PR DESCRIPTION
Stacked PRs:
 * #74
 * __->__#73
 * #72


--- --- ---

### Allow specifying the location for the branch number in the branch name template.


Previously the branch number was always at the end after `/`. This PR
generalizes it and allows it to be present anywhere in the template
under the placeholder "$ID".

Fixes #57.
