### PR TITLE
Fix bug with 'git remote set-branches origin main'

### DIFF
--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -636,7 +636,7 @@ def set_head_branches(
 ) -> None:
     """Set the head ref for each stack entry if it doesn't already have one."""
 
-    run_shell_command(["git", "fetch", "--prune", remote], quiet=not verbose)
+    run_shell_command(["git", "fetch", "--prune", remote, f"+refs/heads/*:refs/remotes/{remote}/*"], quiet=not verbose)
     available_name = get_available_branch_name(remote, branch_name_template)
     for e in filter(lambda e: not e.has_head(), st):
         e.head = available_name


### PR DESCRIPTION
I was hitting a bug where every PR would use the same name `jansel/stack/1`, for example:
```
$ stack-pr view
VIEW
Stack:
   * 87de0037 (no PR, 'jansel/stack/1' -> 'jansel/stack/1'): ...
   * 683f11a4 (#81, 'jansel/stack/1' -> 'main'): ...
```
`jansel/stack/2` would never get used, and stack-pr would clobber itself and be very broken.


The issue was my git was configured to only fetch `main` rather than all branches.  You can repro this with:
```
git remote set-branches origin main
```
(and also delete all your local cached remote refs).

One fix would be:
```
git remote set-branches origin '*'
```
however, this modifies my global git config -- and users won't know they need to run that command.

This PR fixes the issue by forcing all branches to be fetched.

One potential improvement would be a more narrow fetch like:
```
+refs/heads/jansel/stack/*:refs/remotes/origin/jansel/stack/*
```
which will make stack-pr faster in large multi-user projects, though I will leave that to others to implement since I don't have a great testing setup.




