### PR TITLE
Make submit work with 'git rebase -i'

### DIFF
--- a/src/stack_pr/shell_commands.py
+++ b/src/stack_pr/shell_commands.py
@@ -45,7 +45,8 @@ def run_shell_command(
         raise ValueError("shell support has been removed")
     _ = subprocess.list2cmdline(cmd)
     if quiet:
-        kwargs.update({"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL})
+        # Use pipes so errors result in usable error messages
+        kwargs.update({"stdout": subprocess.PIPE, "stderr": subprocess.PIPE})
     logger.debug("Running: %s", cmd)
     return subprocess.run(list(map(str, cmd)), **kwargs, check=check)
 


### PR DESCRIPTION
My workflow is I have a bunch of commits, say:
```
C
B
A
```
but I only want to submit `A` and `B`. So I run:
1) `git rebase -i`, stop to edit `B`
2) `stack-pr submit`
3) `git rebase --continue`

This was broken, because
- A rebase in progress makes the `git rebase` command issued by `stack-pr` fail
- Being in a detatched head state wasn't handled well

This PR fixes those.  cc @ZolotukhinM 

