### PR TITLE
Fix call of `gh pr edit` on returning `Warning`

### DIFF
--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -781,6 +781,7 @@ def add_cross_links(st: list[StackEntry], *, keep_body: bool, verbose: bool) -> 
                 ["gh", "pr", "edit", e.pr, "-t", title, "-F", "-", "-B", e.base or ""],
                 input="\n".join(pr_body).encode(),
                 quiet=not verbose,
+                check=False,
             )
         else:
             error("Stack entry has no base branch")


### PR DESCRIPTION
The issue is on the call on `cli.py`:

~~~python

run_shell_command(
    ["gh", "pr", "edit", e.pr, "-t", title, "-F", "-", "-B", e.base or ""],
    input="\n".join(pr_body).encode(),
    quiet=not verbose,
)
~~~

The run_shell_command function has check=True as its default parameter (line 27 in shell_commands.py). This means when gh pr edit returns exit code 1 (even for just a warning about Projects classic deprecation), it raises a CalledProcessError.