### PR TITLE
Add 'land.style' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,11 @@ Options:
 
 Land the bottom-most PR in the current stack.
 
-Takes no additional arguments beyond common ones.
+Options:
+
+- `--land-style`: Style of landing PRs. Choices: `disable`, `bottom-only` (default: `bottom-only` or from config)
+  - `bottom-only`: Land one PR at a time (bottom-most in the stack)
+  - `disable`: Disable the land command entirely, requiring PRs to be merged through GitHub web interface
 
 #### abandon
 
@@ -397,6 +401,12 @@ stack-pr config repo.reviewer=user1,user2
 
 # Set custom branch name template
 stack-pr config repo.branch_name_template=$USERNAME/stack
+
+# Disable the land command (require GitHub web interface for merging)
+stack-pr config land.style=disable
+
+# Use "bottom-only" landing style for stacks
+stack-pr config land.style=bottom-only
 ```
 
 The config command modifies the config file (`.stack-pr.cfg` by default, or the path specified by `STACKPR_CONFIG` environment variable). If the file doesn't exist, it will be created. If a setting already exists, it will be updated.
@@ -421,4 +431,6 @@ remote=origin
 target=main
 reviewer=GithubHandle1,GithubHandle2
 branch_name_template=$USERNAME/$BRANCH
+[land]
+style=bottom-only
 ```

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -198,6 +198,16 @@ ERROR_TARGET_BRANCH_MISSING = """Could not find target branch '{remote}/{target}
 
 Make sure the branch exists or specify a different target with --target option.
 """
+ERROR_LAND_DISABLED = """The 'land' command is disabled.
+
+Please merge your PRs through the GitHub web interface instead.
+
+To override this setting for a single command:
+  stack-pr land --land-style=bottom-only
+
+Or to re-enable it permanently:
+  stack-pr config land.style=bottom-only
+"""
 UPDATE_STACK_TIP = """
 If you'd like to push your local changes first, you can use the following command to update the stack:
   $ stack-pr export -B {top_commit}~{stack_size} -H {top_commit}"""
@@ -881,6 +891,7 @@ class CommonArgs:
     hyperlinks: bool
     verbose: bool
     branch_name_template: str
+    land_style: str
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> CommonArgs:
@@ -892,6 +903,7 @@ class CommonArgs:
             args.hyperlinks,
             args.verbose,
             args.branch_name_template,
+            args.land_style,
         )
 
 
@@ -972,6 +984,7 @@ def deduce_base(args: CommonArgs) -> CommonArgs:
         args.hyperlinks,
         args.verbose,
         args.branch_name_template,
+        args.land_style,
     )
 
 
@@ -1209,6 +1222,11 @@ def delete_remote_branches(
 # ===----------------------------------------------------------------------=== #
 def command_land(args: CommonArgs) -> None:
     log(h("LAND"), level=1)
+
+    # Check if land command is disabled
+    if args.land_style == "disable":
+        error(ERROR_LAND_DISABLED)
+        sys.exit(1)
 
     current_branch = get_current_branch_name()
 
@@ -1517,6 +1535,12 @@ def create_argparser(
         "--branch-name-template",
         default=config.get("repo", "branch_name_template", fallback="$USERNAME/stack"),
         help="A template for names of the branches stack-pr would use.",
+    )
+    common_parser.add_argument(
+        "--land-style",
+        default=config.get("land", "style", fallback="bottom-only"),
+        choices=["disable", "bottom-only"],
+        help="Style of landing PRs: 'bottom-only' lands one PR per invocation, 'disable' disables the land command.",
     )
 
     parser_submit = subparsers.add_parser(


### PR DESCRIPTION
Stacked PRs:
 * __->__#102


--- --- ---

### Add 'land.style' option.


The option can be used to disable 'land' command entirely, or use the
currently implemented 'bottom-only' style of landing. In future we might
implement other styles, such as "one-by-one" and "rebase-and-land".