### PR TITLE
Fix local branch rebasing after land

### DIFF
--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -1285,6 +1285,13 @@ def command_land(args: CommonArgs) -> None:
     # already be there from the metadata that commits need to have by that
     # point.
     set_base_branches(st, args.target)
+
+    # If the current branch contains commits from the stack, rebase it onto the
+    # updated stack tip in the end so it reuses the same rewritten commits as
+    # the PR branches.
+    top_commit = st[-1].commit.commit_id()
+    need_to_rebase_current = is_ancestor(top_commit, current_branch, verbose=args.verbose)
+
     print_stack(st, links=args.hyperlinks)
 
     # Verify that the stack is correct before trying to land it.
@@ -1293,6 +1300,11 @@ def command_land(args: CommonArgs) -> None:
     # All good, land the bottommost PR!
     land_pr(st[0], remote=args.remote, target=args.target, verbose=args.verbose)
 
+    # Refresh the local view of the target branch after the merge.
+    run_shell_command(["git", "fetch", "--prune", args.remote], quiet=not args.verbose)
+
+    current_branch_base = f"{args.remote}/{args.target}"
+
     # The rest of the stack now needs to be rebased.
     if len(st) > 1:
         log(h("Rebasing the rest of the stack"), level=1)
@@ -1300,6 +1312,9 @@ def command_land(args: CommonArgs) -> None:
         print_stack(prs_to_rebase, links=args.hyperlinks, level=1)
         for e in prs_to_rebase:
             rebase_pr(e, remote=args.remote, target=args.target, verbose=args.verbose)
+
+        current_branch_base = prs_to_rebase[-1].head
+
         # Change the target of the new bottom-most PR in the stack to 'target'
         run_shell_command(
             ["gh", "pr", "edit", prs_to_rebase[0].pr, "-B", args.target],
@@ -1317,10 +1332,12 @@ def command_land(args: CommonArgs) -> None:
             ["git", "rebase", f"{args.remote}/{args.target}", args.target],
             quiet=not args.verbose,
         )
-    run_shell_command(
-        ["git", "rebase", f"{args.remote}/{args.target}", current_branch],
-        quiet=not args.verbose,
-    )
+
+    rebase_base = current_branch_base if need_to_rebase_current else f"{args.remote}/{args.target}"
+    cmd = ["git", "rebase", rebase_base, current_branch]
+    if need_to_rebase_current:
+        cmd.append("--committer-date-is-author-date")
+    run_shell_command(cmd, quiet=not args.verbose)
 
     log(h(blue("SUCCESS!")))
 

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -1313,7 +1313,11 @@ def command_land(args: CommonArgs) -> None:
         for e in prs_to_rebase:
             rebase_pr(e, remote=args.remote, target=args.target, verbose=args.verbose)
 
-        current_branch_base = prs_to_rebase[-1].head
+        # Resolve the rewritten tip to a commit hash before the local stack
+        # branches are deleted below.
+        current_branch_base = get_command_output(
+            ["git", "rev-parse", prs_to_rebase[-1].head]
+        ).strip()
 
         # Change the target of the new bottom-most PR in the stack to 'target'
         run_shell_command(

--- a/tests/test_land.py
+++ b/tests/test_land.py
@@ -1,0 +1,98 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from stack_pr import cli
+
+
+def make_args() -> cli.CommonArgs:
+    return cli.CommonArgs(
+        base="base",
+        head="head",
+        remote="origin",
+        target="main",
+        hyperlinks=False,
+        verbose=False,
+        branch_name_template="$USERNAME/stack/$ID",
+        show_tips=False,
+        land_disabled=False,
+    )
+
+
+def make_entry(head: str, pr: str, commit_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        head=head,
+        pr=pr,
+        commit=SimpleNamespace(commit_id=lambda: commit_id),
+    )
+
+
+def test_land_rebases_current_branch_onto_updated_stack_tip(
+    monkeypatch,
+) -> None:
+    commands: list[list[str]] = []
+    stack = [make_entry("stack/1", "pr-1", "commit-1"), make_entry("stack/2", "pr-2", "commit-2")]
+
+    monkeypatch.setattr(cli, "get_current_branch_name", lambda: "feature")
+    monkeypatch.setattr(cli, "should_update_local_base", lambda **kwargs: False)
+    monkeypatch.setattr(cli, "get_stack", lambda **kwargs: stack)
+    monkeypatch.setattr(cli, "set_base_branches", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "print_stack", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "verify", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "land_pr", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "rebase_pr", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "delete_local_branches", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "branch_exists", lambda branch: False)
+    monkeypatch.setattr(
+        cli,
+        "is_ancestor",
+        lambda ancestor, descendant, *, verbose: ancestor == "commit-2"
+        and descendant == "feature",
+    )
+
+    def fake_run_shell_command(cmd, *, quiet, check=True, **kwargs):
+        commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(cli, "run_shell_command", fake_run_shell_command)
+
+    cli.command_land(make_args())
+
+    assert ["git", "rebase", "stack/2", "feature", "--committer-date-is-author-date"] in commands
+    assert ["git", "rebase", "origin/main", "feature"] not in commands
+
+
+def test_land_refreshes_remote_target_before_rebasing_current_branch(
+    monkeypatch,
+) -> None:
+    commands: list[list[str]] = []
+    stack = [make_entry("stack/1", "pr-1", "commit-1")]
+
+    monkeypatch.setattr(cli, "get_current_branch_name", lambda: "feature")
+    monkeypatch.setattr(cli, "should_update_local_base", lambda **kwargs: False)
+    monkeypatch.setattr(cli, "get_stack", lambda **kwargs: stack)
+    monkeypatch.setattr(cli, "set_base_branches", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "print_stack", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "verify", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "land_pr", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "delete_local_branches", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "branch_exists", lambda branch: False)
+    monkeypatch.setattr(
+        cli,
+        "is_ancestor",
+        lambda ancestor, descendant, *, verbose: ancestor == "commit-1"
+        and descendant == "feature",
+    )
+
+    def fake_run_shell_command(cmd, *, quiet, check=True, **kwargs):
+        commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(cli, "run_shell_command", fake_run_shell_command)
+
+    cli.command_land(make_args())
+
+    assert ["git", "fetch", "--prune", "origin"] in commands
+    assert ["git", "rebase", "origin/main", "feature", "--committer-date-is-author-date"] in commands

--- a/tests/test_land.py
+++ b/tests/test_land.py
@@ -47,6 +47,13 @@ def test_land_rebases_current_branch_onto_updated_stack_tip(
     monkeypatch.setattr(cli, "branch_exists", lambda branch: False)
     monkeypatch.setattr(
         cli,
+        "get_command_output",
+        lambda cmd, **kwargs: "rebased-stack-tip\n"
+        if cmd == ["git", "rev-parse", "stack/2"]
+        else "",
+    )
+    monkeypatch.setattr(
+        cli,
         "is_ancestor",
         lambda ancestor, descendant, *, verbose: ancestor == "commit-2"
         and descendant == "feature",
@@ -60,7 +67,14 @@ def test_land_rebases_current_branch_onto_updated_stack_tip(
 
     cli.command_land(make_args())
 
-    assert ["git", "rebase", "stack/2", "feature", "--committer-date-is-author-date"] in commands
+    assert [
+        "git",
+        "rebase",
+        "rebased-stack-tip",
+        "feature",
+        "--committer-date-is-author-date",
+    ] in commands
+    assert ["git", "rebase", "stack/2", "feature", "--committer-date-is-author-date"] not in commands
     assert ["git", "rebase", "origin/main", "feature"] not in commands
 
 


### PR DESCRIPTION
## Summary

This change updates `stack-pr land` so that when the current branch contains the stack being landed, the local branch is rebased onto the updated stack tip rather than being rebased independently onto `origin/main`.

As a result, the local branch now reuses the same rewritten commits as the remaining PR branches after landing, and then rebases any additional local commits on top as usual.

This PR also includes a follow-up fix so that the rewritten stack tip is resolved to a stable commit hash before local stack branches are cleaned up.

## Problem

Previously, `stack-pr land` would:

1. land the bottom-most PR,
2. rebase the remaining PR branches, and then
3. rebase the current branch directly onto `origin/<target>`.

That preserved equivalent content, but it did not guarantee that the local branch would be based on the same commit chain as the PR branches. In practice, the local branch could diverge from the rewritten stack and end up with different commit identities.

A follow-up regression also remained when PRs still existed above the landed one: the command tracked the rewritten remaining stack tip by local branch name, then deleted the local stack branches before rebasing the current branch. In real usage this could fail with `fatal: invalid upstream '<branch>'`.

## Fix

This change adjusts `command_land` to:

- detect whether the current branch contains the stack being landed,
- refresh the remote target branch after the merge,
- track the correct post-land base for the current branch,
- rebase the current branch onto the updated stack tip when appropriate, and
- resolve the rewritten remaining stack tip to a commit hash before deleting local stack branches.

If there are no remaining PRs in the stack, the current branch is still rebased onto the refreshed `origin/<target>`.

## Tests

Added regression coverage for the `land` command flow:

- verify the current branch is rebased onto the updated remaining stack tip when PRs remain,
- verify the rewritten stack tip is resolved before local stack branches are deleted,
- verify the stale branch name is not used for the final current-branch rebase,
- verify the target branch is refreshed before rebasing the current branch.

## Validation

Validated locally with:

- `python3 -m py_compile src/stack_pr/cli.py tests/test_land.py`
- `pytest tests/test_land.py`
- `pytest`

The pytest runs were executed in the repo's pyenv virtualenv (`Python 3.9.25`).

Pytest emits two existing config warnings about unknown `asyncio_default_fixture_loop_scope` and `asyncio_mode` options, but all tests pass.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author