### PR TITLE
Target landed PR's merge commit in autoland workflow checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Top of tree
 
+* Fixed `autoland` workflow checkpoints (`w <workflow>`) polling forever in
+  busy repos. The checkpoint targeted the current `origin/<target>` HEAD, which
+  can advance past the landed PR's merge commit (bot commits, other PRs) between
+  merge and the check — so a green workflow run on the actual merge commit was
+  rejected as "too old". The checkpoint now targets the landed PR's exact merge
+  commit.
 * Fixed a crash during `submit` when a PR in the stack had been added to a
   GitHub merge queue. GitHub refuses to change such a PR's base branch, which
   previously aborted the whole submit; now stack-pr warns and leaves that PR's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@
 * Added an `autoland` command that lands a whole stack through the GitHub merge
   queue (waits for approval/CI with flaky-check retries, enqueues bottom-to-top,
   rebases and re-submits after each merge, and supports `--resume`, `--branch`
-  worktrees, and interactive deploy/confirm checkpoints). Repo-specific settings
-  live under `[autoland]` config; requires `autoland.merge_queue=true`. Install
-  the optional `rich` extra for live progress tables.
+  worktrees, and interactive checkpoints). Interactive (`-i`) landing plans
+  support `w <workflow>` steps (wait for a named GitHub Actions workflow to
+  complete with the landed code) and `c <message>` confirmation steps between
+  land steps. Repo-specific settings live under `[autoland]` config; requires
+  `autoland.merge_queue=true`. Install the optional `rich` extra for live
+  progress tables. (#3, #7)
 * Added an `install` command that registers stack-pr as a git alias (e.g.
   `git stack`), plus a `help` command so `git stack help` works (git intercepts
   `git stack --help` for aliases).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Top of tree
 
+* Fixed a crash during `submit` when a PR in the stack had been added to a
+  GitHub merge queue. GitHub refuses to change such a PR's base branch, which
+  previously aborted the whole submit; now stack-pr warns and leaves that PR's
+  base unchanged while still updating its title/body.
 * Added an `adopt` command to bring an existing, normally-created PR under
   stack-pr management without closing and recreating it. Supports a `--commit`
   option to attach the PR to a specific commit (e.g. when inserting a new PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@
   worktrees, and interactive checkpoints). Interactive (`-i`) landing plans
   support `w <workflow>` steps (wait for a named GitHub Actions workflow to
   complete with the landed code) and `c <message>` confirmation steps between
-  land steps. Repo-specific settings live under `[autoland]` config; requires
-  `autoland.merge_queue=true`. Install the optional `rich` extra for live
-  progress tables. (#3, #7)
+  land steps; setting `autoland.default_workflow` pre-fills the plan with a
+  trailing `w <default_workflow>` step. Repo-specific settings live under
+  `[autoland]` config; requires `autoland.merge_queue=true`. Install the
+  optional `rich` extra for live progress tables. (#3, #7, #8)
 * Added an `install` command that registers stack-pr as a git alias (e.g.
   `git stack`), plus a `help` command so `git stack help` works (git intercepts
   `git stack --help` for aliases).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 * The `Stacked PRs:` cross-links list is now maintained as PRs land: merged and
   closed PRs are kept in the list of later PRs instead of disappearing after a
   subsequent `submit` (#53).
+* Added an `autoland` command that lands a whole stack through the GitHub merge
+  queue (waits for approval/CI with flaky-check retries, enqueues bottom-to-top,
+  rebases and re-submits after each merge, and supports `--resume`, `--branch`
+  worktrees, and interactive deploy/confirm checkpoints). Repo-specific settings
+  live under `[autoland]` config; requires `autoland.merge_queue=true`. Install
+  the optional `rich` extra for live progress tables.
 
 # Version 0.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   worktrees, and interactive deploy/confirm checkpoints). Repo-specific settings
   live under `[autoland]` config; requires `autoland.merge_queue=true`. Install
   the optional `rich` extra for live progress tables.
+* Added an `install` command that registers stack-pr as a git alias (e.g.
+  `git stack`), plus a `help` command so `git stack help` works (git intercepts
+  `git stack --help` for aliases).
 
 # Version 0.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Top of tree
 
+* Added an `adopt` command to bring an existing, normally-created PR under
+  stack-pr management without closing and recreating it. Supports a `--commit`
+  option to attach the PR to a specific commit (e.g. when inserting a new PR
+  underneath an existing one) (#121).
+
 # Version 0.1.3
 
 * Fix a bug with replacing $USERNAME in the branch name. (#44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   stack-pr management without closing and recreating it. Supports a `--commit`
   option to attach the PR to a specific commit (e.g. when inserting a new PR
   underneath an existing one) (#121).
+* The `Stacked PRs:` cross-links list is now maintained as PRs land: merged and
+  closed PRs are kept in the list of later PRs instead of disappearing after a
+  subsequent `submit` (#53).
 
 # Version 0.1.3
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ That's it!
   This embeds stack metadata into the bottom-most commit pointing at that PR, so
   subsequent `submit` runs update the existing PR (preserving its review
   history) instead of creating a new one.
+- `autoland` - land the whole stack automatically through the GitHub merge
+  queue: wait for approvals and CI (retrying flaky checks), enqueue each PR
+  bottom-to-top, rebase and re-submit the rest after each merge, and resume
+  cleanly after an interruption. Requires a repo that uses the GitHub merge
+  queue (see `autoland.merge_queue` below).
 - `config` - set configuration values in the config file. Similar to `git config`,
   it takes a setting in the format `<section>.<key>=<value>` and updates the
   config file (`.stack-pr.cfg` by default).
@@ -456,6 +461,58 @@ Stacking a new PR *underneath* an existing one (so the new change lands first):
 Alternatively, build the stack in any order first and then adopt the existing
 PR onto the right commit directly with `stack-pr adopt --commit <ref>`.
 
+#### autoland
+
+Land the entire stack automatically through the GitHub merge queue, one PR at a
+time from the bottom up. Run it from the repo root while on the stack's head
+branch. For each PR it waits for approval and CI (re-running flaky checks),
+adds the PR to the merge queue (retrying if the PR is booted), and after each
+merge rebases and re-submits the rest of the stack. Progress is checkpointed so
+an interrupted run can be resumed.
+
+> **Note**: `autoland` currently supports only repositories that use the GitHub
+> merge queue. On other repositories it fails fast with a "not implemented"
+> error; use `stack-pr land` instead. (Direct-merge autoland is future work.)
+
+Options:
+
+- `--dry-run`: Discover and display the stack, then exit.
+- `--branch BRANCH`: Land a stack rooted on `BRANCH` using a temporary worktree
+  (so your current checkout is left untouched). The worktree is removed on
+  success and preserved on failure for debugging.
+- `--always-cleanup`: Always remove the temporary worktree, even on failure.
+- `-i, --interactive`: Edit the landing plan in `$EDITOR` first, inserting
+  `deploy` checkpoints (wait for a named workflow to ship the landed code) and
+  `confirm` checkpoints (pause for manual confirmation) between land steps.
+- `--resume`: Resume a previously interrupted run from its checkpoint.
+- `--state-file PATH`: Override the checkpoint path (default:
+  `~/.stack-pr/autoland/<branch>.json`).
+- `--poll-interval`, `--max-check-retries`, `--max-queue-retries`,
+  `--deploy-timeout`: Override the corresponding `[autoland]` config values.
+
+Everything repo-specific is configured under `[autoland]` (see [Config
+files](#config-files)), so a repository captures its workflow in
+`.stack-pr.cfg`:
+
+```ini
+[repo]
+target = main
+[autoland]
+merge_queue = true
+required_checks = test,lint
+poll_interval = 120
+max_check_retries = 3
+max_queue_retries = 3
+```
+
+- `merge_queue` (default `false`): must be `true` to enable `autoland`.
+- `required_checks` (default empty): comma-separated CI check names that gate a
+  merge. When empty, all reported (non-skipped) checks must pass.
+
+Richer live progress tables are shown when the optional `rich` dependency is
+installed (`pipx install 'stack-pr[rich]'` or add the `rich` extra); otherwise
+`autoland` prints plain-text status.
+
 #### view
 
 Inspect the current stack
@@ -520,6 +577,14 @@ reviewer=GithubHandle1,GithubHandle2
 branch_name_template=$USERNAME/$BRANCH
 [land]
 style=bottom-only
+[autoland]
+merge_queue=True
+required_checks=test,lint
+poll_interval=120
+max_check_retries=3
+max_queue_retries=3
+merge_timeout=3600
+deploy_timeout=10800
 ```
 
 ## Implementation Details

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ pipx install .
 
 `stack-pr` allows you to work with stacked PRs: submit, view, and land them.
 
+### Use as a git subcommand
+
+If you'd rather drive the tool through `git`, install it as a git alias:
+
+```bash
+stack-pr install
+```
+
+```bash
+git stack view
+git stack submit
+```
 ### Basic Workflow
 
 The most common workflow is simple:
@@ -143,6 +155,10 @@ That's it!
 - `config` - set configuration values in the config file. Similar to `git config`,
   it takes a setting in the format `<section>.<key>=<value>` and updates the
   config file (`.stack-pr.cfg` by default).
+- `install` - install stack-pr as a git alias so it can be invoked as
+  `git stack` (see [Use as a git subcommand](#use-as-a-git-subcommand)).
+- `help` - print help. Useful as `git stack help`, since `git stack --help` is
+  intercepted by git for aliases.
 
 A usual workflow is the following:
 
@@ -553,6 +569,29 @@ stack-pr config land.style=bottom-only
 ```
 
 The config command modifies the config file (the `.stack-pr.cfg` file in the repo root by default, or the path specified by `STACKPR_CONFIG` environment variable). If the file doesn't exist, it will be created. If a setting already exists, it will be updated.
+
+#### install
+
+Install stack-pr as a git alias so it can be invoked as `git <name>` (see
+[Use as a git subcommand](#use-as-a-git-subcommand)). This writes
+`alias.<name> = !stack-pr` to your git config.
+
+Options:
+
+- `--name`: Alias name to create (default: `stack`, i.e. `git stack ...`).
+- `--local`: Write to the current repository's git config instead of the
+  global one.
+
+#### help
+
+Print help, optionally for a specific subcommand. This exists primarily so
+`git stack help` works: git intercepts `git stack --help` for aliases and only
+prints `'stack' is aliased to '!stack-pr'`.
+
+Arguments:
+
+- `topic` (optional): Subcommand to show help for, e.g. `stack-pr help submit`
+  (or `git stack help submit`).
 
 ### Config files
 

--- a/README.md
+++ b/README.md
@@ -519,7 +519,9 @@ Options:
 - `-i, --interactive`: Edit the landing plan in `$EDITOR` first, inserting
   `workflow` checkpoints (`w <workflow>` — wait for a named GitHub Actions
   workflow to complete with the landed code) and `confirm` checkpoints (`c
-  <message>` — pause for manual confirmation) between land steps.
+  <message>` — pause for manual confirmation) between land steps. When
+  `autoland.default_workflow` is configured, the pre-filled plan already ends
+  with a `w <default_workflow>` step, which you can edit or delete.
 - `--resume`: Resume a previously interrupted run from its checkpoint.
 - `--state-file PATH`: Override the checkpoint path (default:
   `~/.stack-pr/autoland/<branch>.json`).
@@ -539,11 +541,16 @@ required_checks = test,lint
 poll_interval = 120
 max_check_retries = 3
 max_queue_retries = 3
+default_workflow = deploy.yaml
 ```
 
 - `merge_queue` (default `false`): must be `true` to enable `autoland`.
 - `required_checks` (default empty): comma-separated CI check names that gate a
   merge. When empty, all reported (non-skipped) checks must pass.
+- `default_workflow` (default empty): when set, an interactive (`-i`) landing
+  plan is pre-filled with a `w <default_workflow>` step after the land steps,
+  so a repo's usual post-land workflow wait is there by default (still
+  editable/removable in `$EDITOR`).
 
 Richer live progress tables are shown when the optional `rich` dependency is
 installed (`pipx install 'stack-pr[rich]'` or add the `rich` extra); otherwise
@@ -647,6 +654,7 @@ max_check_retries=3
 max_queue_retries=3
 merge_timeout=3600
 workflow_timeout=10800
+default_workflow=deploy.yaml
 ```
 
 ## Implementation Details

--- a/README.md
+++ b/README.md
@@ -517,13 +517,14 @@ Options:
   success and preserved on failure for debugging.
 - `--always-cleanup`: Always remove the temporary worktree, even on failure.
 - `-i, --interactive`: Edit the landing plan in `$EDITOR` first, inserting
-  `deploy` checkpoints (wait for a named workflow to ship the landed code) and
-  `confirm` checkpoints (pause for manual confirmation) between land steps.
+  `workflow` checkpoints (`w <workflow>` — wait for a named GitHub Actions
+  workflow to complete with the landed code) and `confirm` checkpoints (`c
+  <message>` — pause for manual confirmation) between land steps.
 - `--resume`: Resume a previously interrupted run from its checkpoint.
 - `--state-file PATH`: Override the checkpoint path (default:
   `~/.stack-pr/autoland/<branch>.json`).
 - `--poll-interval`, `--max-check-retries`, `--max-queue-retries`,
-  `--deploy-timeout`: Override the corresponding `[autoland]` config values.
+  `--workflow-timeout`: Override the corresponding `[autoland]` config values.
 
 Everything repo-specific is configured under `[autoland]` (see [Config
 files](#config-files)), so a repository captures its workflow in
@@ -645,7 +646,7 @@ poll_interval=120
 max_check_retries=3
 max_queue_retries=3
 merge_timeout=3600
-deploy_timeout=10800
+workflow_timeout=10800
 ```
 
 ## Implementation Details

--- a/README.md
+++ b/README.md
@@ -15,11 +15,19 @@ Example:
 
 ![StackedPRExample1](https://modular-assets.s3.amazonaws.com/images/stackpr/example_0.png)
 
+## Comparison
+
+There are several tool that help with stacked PRs.
+
+- stack-pr (this project): A stack is a set of commits on a branch. Each commit is one PR. The commits are modified over time via a interactive rebase-based workflow. Each PR description automatically gets a preamble section showing the full stack. The tool manages a mapping from commit => temp branch => PR with state stored in the commit body itself. Support for GitHub only via the `gh` CLI.
+- [git-spice](https://abhinav.github.io/git-spice/): A stack is a set of branches. Each branch is one PR. The branches are modified over time via normal git operations. Branches must be tracked by the tool with a separate local state store. A special restack commit rebases all the branches. Support for non-linear stack branches and multiple git hosting providers.
+- [jj-stack](https://github.com/keanemind/jj-stack/): A stack is a set of Jujutsu bookmarks. Jujutsu already conceptually supports stacks locally, so this tool focuses on syncing the local repo state to GitHub.
+
 ## Installation
 
 ### Dependencies
 
-This is a non-comprehensive list of dependencies required by `stack-pr.py`:
+This is a non-comprehensive list of dependencies required by `stack-pr`:
 
 - Install `gh`, e.g., `brew install gh` on MacOS.
 - Run `gh auth login` with SSH
@@ -31,7 +39,7 @@ This fork is not published to PyPI. To install it directly from the GitHub repo
 via [pipx](https://pipx.pypa.io/stable/) run:
 
 ```bash
-pipx install git+https://github.com/micahjsmith/stack-pr.git
+pipx install 'stack-pr[rich] @ git+https://github.com/micahjsmith/stack-pr.git'
 ```
 
 ### Manual installation from source
@@ -102,7 +110,7 @@ git rebase main       # Rebase your commits on top of main
 stack-pr submit       # Resubmit to update all PRs
 ```
 
-7. When your PRs are ready to merge, you have two options:
+7. When your PRs are ready to merge, you have three options:
 
 **Option A**: Using `stack-pr land`:
 ```bash
@@ -123,6 +131,11 @@ This will:
    ```
 3. Repeat for each PR in the stack
 
+**Option C**: Using `stack-pr autoland` (if your repo uses GitHub merge queue):
+```bash
+stack-pr autoland
+```
+
 That's it!
 
 > **Pro-tip**: Run `stack-pr view` frequently - it's a safe command that helps you understand the current state of your stack and catch any potential issues early.
@@ -141,12 +154,15 @@ That's it!
 - `abandon` - remove all stack metadata from the given set of commits. Apart
   from removing the metadata from the affected commits, this command deletes
   the corresponding local and remote branches and closes the PRs.
-- `land` - merge the bottom-most PR in the current stack and rebase the rest of
-  the stack on the latest main.
 - `adopt` - bring an existing, normally-created PR under `stack-pr` management.
   This embeds stack metadata into the bottom-most commit pointing at that PR, so
   subsequent `submit` runs update the existing PR (preserving its review
   history) instead of creating a new one.
+- `land` - merge the bottom-most PR in the current stack and rebase the rest of
+  the stack on the latest main.
+
+`stack-pr` also has several other commands:
+
 - `autoland` - land the whole stack automatically through the GitHub merge
   queue: wait for approvals and CI (retrying flaky checks), enqueue each PR
   bottom-to-top, rebase and re-submit the rest after each merge, and resume
@@ -166,18 +182,21 @@ A usual workflow is the following:
 while not ready to merge:
     make local changes
     commit to local git repo or amend existing commits
-    create or update the stack with `stack-pr.py submit`
-merge changes with `stack-pr.py land`
+    create or update the stack with `stack-pr submit`
+merge changes with `stack-pr land`
 ```
 
 You can also use `view` at any point to examine the current state, and
 `abandon` to drop the stack.
 
-Under the hood the tool creates and maintains branches named
+### How it works
+
+Under the hood, the tool creates and maintains branches named
 `$USERNAME/stack/$BRANCH_NUM` (the name pattern can be customized via
-`--branch-name-template` option) and embeds stack metadata into commit messages,
-but you are not supposed to work with those branches or edit that metadata
-manually. I.e. instead of pushing to these branches you should use `submit`,
+`--branch-name-template` option) and embeds stack metadata into commit messages (see [](#implementation-details)).
+
+You don't work with those managed branches or edit that metadata
+manually. Instead of pushing to these branches you should use `submit`,
 instead of deleting them you should use `abandon` and instead of merging them
 you should use `land`.
 
@@ -609,13 +628,16 @@ draft=False
 keep_body=False
 stash=False
 show_tips=True
+
 [repo]
 remote=origin
 target=main
 reviewer=GithubHandle1,GithubHandle2
 branch_name_template=$USERNAME/$BRANCH
+
 [land]
 style=bottom-only
+
 [autoland]
 merge_queue=True
 required_checks=test,lint

--- a/README.md
+++ b/README.md
@@ -552,6 +552,21 @@ the target branch for the bottom-most PR).
 
 Because the trailer is just text in the commit message, a commit can be brought
 under `stack-pr` management by adding it (which is what `adopt` does for an
-existing PR), and removed by deleting it (which is what `abandon` does). The
-cross-links between PRs in a stack are rendered into the PR body and are
-regenerated on each `submit`.
+existing PR), and removed by deleting it (which is what `abandon` does).
+
+### Cross-links between PRs
+
+Each PR's body contains a `Stacked PRs:` table of contents listing every PR in
+the stack (with `__->__` marking the current one). This list is regenerated on
+each `submit`, and it is *maintained* as PRs land: a PR that has left the active
+stack but has merged or been closed is kept in the list (pinned below the active
+PRs in its original position), so later PRs retain the full history of the
+stack. A PR that left the stack but is still open is dropped.
+
+The list is stored only in the PR bodies - on each `submit`, `stack-pr` reads
+the previously recorded list back from a surviving PR's body, re-checks the
+status of any entries that are no longer in the active stack, and writes the
+reconciled list to every PR. As a result, merged/closed entries are pinned at
+the bottom of the list; inserting a brand-new commit *below* an
+already-merged one is the one case where an entry can appear slightly out of
+order.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ That's it!
   the corresponding local and remote branches and closes the PRs.
 - `land` - merge the bottom-most PR in the current stack and rebase the rest of
   the stack on the latest main.
+- `adopt` - bring an existing, normally-created PR under `stack-pr` management.
+  This embeds stack metadata into the bottom-most commit pointing at that PR, so
+  subsequent `submit` runs update the existing PR (preserving its review
+  history) instead of creating a new one.
 - `config` - set configuration values in the config file. Similar to `git config`,
   it takes a setting in the format `<section>.<key>=<value>` and updates the
   config file (`.stack-pr.cfg` by default).
@@ -370,6 +374,88 @@ Abandon the current stack.
 
 Takes no additional arguments beyond common ones.
 
+#### adopt
+
+Bring an existing, normally-created PR under `stack-pr` management. This is
+useful when you opened a PR the usual way (with its own review history) and now
+want to stack more PRs on top of it.
+
+By default `adopt` looks at the bottom-most commit of the current range
+(`main..HEAD` by default) and embeds stack metadata into it pointing at the
+target PR. Once adopted, run `stack-pr submit` to update that PR and push the
+rest of the stack; the original PR is updated in place rather than closed and
+recreated.
+
+Arguments:
+
+- `pr` (optional): PR number or URL to adopt. If omitted, the PR associated with
+  the currently checked-out branch is used.
+
+Options:
+
+- `--commit`: Commit (any git revision) to attach the PR to, when it isn't the
+  bottom-most one - for example when inserting a new PR underneath an existing
+  one. If omitted, the bottom-most commit of the stack is used.
+
+Notes:
+
+- The PR must be in the `OPEN` state.
+- The PR's existing head branch is preserved (recorded in the metadata), so its
+  review history and URL are kept.
+- `submit` will force-push the adopted commit to the PR's branch, so if you
+  have squashed or rebased since opening the PR, its diff will be updated
+  accordingly. `adopt` warns when the local commit's contents differ from the
+  PR's head.
+
+Typical workflow (stack a new PR *on top* of an existing one):
+
+```bash
+# You already have an open PR for branch 'my-feature'.
+git checkout my-feature
+stack-pr adopt                  # adopt the existing PR for 'my-feature' first
+git commit -m "Second change"   # stack a new change on top
+stack-pr view                   # confirm the bottom PR is now managed
+stack-pr submit                 # update the existing PR + create the new one
+```
+
+Stacking a new PR *underneath* an existing one (so the new change lands first):
+
+1. Collapse the branch into a single commit (one commit == one PR) with an
+   interactive rebase, marking every commit except the first as `squash` (or
+   `fixup`):
+
+   ```bash
+   git checkout my-feature
+   git rebase -i $(git merge-base origin/main HEAD)
+   ```
+
+2. Adopt the existing PR onto that commit while it is still the bottom commit:
+
+   ```bash
+   stack-pr adopt
+   ```
+
+3. Insert the new change beneath the adopted commit by building it on top of
+   `main` and rebasing the adopted commit onto it:
+
+   ```bash
+   git checkout -b tmp-new-bottom origin/main
+   # ... make the new change ...
+   git commit -m "New change (lands first)"
+   git rebase --onto tmp-new-bottom origin/main my-feature
+   git branch -D tmp-new-bottom
+   ```
+
+4. Review and submit the stack:
+
+   ```bash
+   stack-pr view     # new commit at the bottom, existing PR on top
+   stack-pr submit   # creates the new PR; re-bases the existing one onto it
+   ```
+
+Alternatively, build the stack in any order first and then adopt the existing
+PR onto the right commit directly with `stack-pr adopt --commit <ref>`.
+
 #### view
 
 Inspect the current stack
@@ -435,3 +521,37 @@ branch_name_template=$USERNAME/$BRANCH
 [land]
 style=bottom-only
 ```
+
+## Implementation Details
+
+### Stack metadata
+
+`stack-pr` does not maintain any state outside of git itself. Instead, it
+tracks the stack by embedding a metadata trailer into each managed commit
+message:
+
+```
+stack-info: PR: https://github.com/<owner>/<repo>/pull/<number>, branch: <head-branch>
+```
+
+This single line is the source of truth for whether a commit is "managed":
+
+- `submit` decides whether to **create** or **update** a PR for each commit by
+  looking for this trailer. A commit without it gets a new branch and a new PR
+  (and the trailer is then written back into the commit message); a commit with
+  it has its existing PR updated.
+- `view` reports the linked PR and branch for each commit by parsing the
+  trailer (showing `No PR` when it is absent).
+- `land` and `abandon` operate only on commits that carry a valid trailer.
+
+The trailer records two fields: the **PR link** and the **head branch** that
+`stack-pr` pushes for that commit (named via `--branch-name-template`, by
+default `$USERNAME/stack/$ID`). The PR's base branch is not stored — it is
+derived from the stack order at runtime (the previous commit's head branch, or
+the target branch for the bottom-most PR).
+
+Because the trailer is just text in the commit message, a commit can be brought
+under `stack-pr` management by adding it (which is what `adopt` does for an
+existing PR), and removed by deleting it (which is what `abandon` does). The
+cross-links between PRs in a stack are rendered into the PR body and are
+regenerated on each `submit`.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ This is a non-comprehensive list of dependencies required by `stack-pr.py`:
 
 ### Installation with `pipx`
 
-To install via [pipx](https://pipx.pypa.io/stable/) run:
+This fork is not published to PyPI. To install it directly from the GitHub repo
+via [pipx](https://pipx.pypa.io/stable/) run:
 
 ```bash
-pipx install stack-pr
+pipx install git+https://github.com/micahjsmith/stack-pr.git
 ```
 
 ### Manual installation from source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dev = [
     "mypy",
     "ruff",
 ]
+# Optional: richer `autoland` output (live status tables). Falls back to
+# plain text when not installed.
+rich = [
+    "rich>=13.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/modular/stack-pr"
@@ -167,6 +172,16 @@ inline-quotes = "double"
 multiline-quotes = "double"
 
 [tool.ruff.lint.extend-per-file-ignores]
+# autoland is a long-running orchestration state machine driving git/gh.
+"src/stack_pr/autoland.py" = [
+    "S101",  # asserts used to narrow gh JSON result types
+    "S607",  # git/gh/$EDITOR invoked by name (same class as the global S603)
+    "C901",  # the land/enqueue/execute loops are intrinsically branchy
+    "PLR0911",
+    "PLR0912",
+    "PLR0915",
+    "TRY300",
+]
 # Allow certain useful patterns in tests
 "tests/**/*.py" = [
     "S101", # allow assert statements within if statements

--- a/src/stack_pr/autoland.py
+++ b/src/stack_pr/autoland.py
@@ -223,7 +223,7 @@ class LandingContext:
     current_index: int = 0  # index into stack for the active land step
     aborted: bool = False
     abort_reason: str = ""
-    last_landed_sha: str = ""  # origin/<target> HEAD after the last merge
+    last_landed_sha: str = ""  # merge commit of the last landed PR
 
 
 # ---------------------------------------------------------------------------
@@ -577,6 +577,18 @@ class GitHub:
         assert isinstance(data, list)
         return data
 
+    def merge_commit(self, pr_number: int) -> str | None:
+        """Return the SHA of the commit ``pr_number`` merged as, if any."""
+        try:
+            data = gh_json(["pr", "view", str(pr_number), "--json", "mergeCommit"])
+        except RuntimeError:
+            return None
+        if isinstance(data, dict):
+            merge = data.get("mergeCommit")
+            if isinstance(merge, dict):
+                return merge.get("oid") or None
+        return None
+
 
 github = GitHub()
 
@@ -793,9 +805,27 @@ def rebase_and_resubmit(common: cli.CommonArgs) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _refresh_last_landed_sha(ctx: LandingContext, common: cli.CommonArgs) -> None:
-    try:
+def _refresh_last_landed_sha(
+    ctx: LandingContext, common: cli.CommonArgs, pr_number: int | None = None
+) -> None:
+    """Record the SHA of the most recently landed code.
+
+    When ``pr_number`` is given, prefer that PR's exact merge commit so the
+    workflow checkpoint targets the code we actually landed. In a busy repo,
+    ``origin/<target>`` can advance past our merge commit (bot commits, other
+    PRs) between the merge and this call, so using its HEAD would overshoot and
+    make the checkpoint wait for a deploy of code that was never our own.
+    """
+    with contextlib.suppress(RuntimeError):  # fetch is non-critical
         run(["git", "fetch", common.remote, common.target], quiet=True)
+
+    if pr_number is not None:
+        merge_sha = github.merge_commit(pr_number)
+        if merge_sha:
+            ctx.last_landed_sha = merge_sha
+            return
+
+    try:
         result = run(
             ["git", "rev-parse", f"{common.remote}/{common.target}"], quiet=True
         )
@@ -1429,7 +1459,7 @@ def execute_plan(
                 console.print(
                     f"\n[green]PR #{entry.pr_number} already merged, skipping[/green]"
                 )
-                _refresh_last_landed_sha(ctx, common)
+                _refresh_last_landed_sha(ctx, common, entry.pr_number)
                 continue
 
             console.print(
@@ -1444,7 +1474,7 @@ def execute_plan(
                 )
 
             if entry.state == PRState.MERGED:
-                _refresh_last_landed_sha(ctx, common)
+                _refresh_last_landed_sha(ctx, common, entry.pr_number)
             else:
                 if not wait_for_checks(entry, opts=opts, ctx=ctx):
                     return _abort(
@@ -1453,14 +1483,14 @@ def execute_plan(
                     )
 
                 if entry.state == PRState.MERGED:
-                    _refresh_last_landed_sha(ctx, common)
+                    _refresh_last_landed_sha(ctx, common, entry.pr_number)
                 else:
                     if not enqueue_and_wait(entry, opts=opts, ctx=ctx):
                         return _abort(
                             ctx, checkpointer,
                             f"PR #{entry.pr_number} failed to merge",
                         )
-                    _refresh_last_landed_sha(ctx, common)
+                    _refresh_last_landed_sha(ctx, common, entry.pr_number)
 
             has_more_land_steps = any(
                 isinstance(s, LandStep) for s in ctx.plan[step_idx + 1 :]

--- a/src/stack_pr/autoland.py
+++ b/src/stack_pr/autoland.py
@@ -91,6 +91,7 @@ class AutolandOptions:
     max_queue_retries: int
     merge_timeout: int
     workflow_timeout: int
+    default_workflow: str | None
     dry_run: bool
     branch: str | None
     interactive: bool
@@ -138,6 +139,9 @@ class AutolandOptions:
                 getattr(args, "workflow_timeout", None),
                 "workflow_timeout",
                 DEFAULT_WORKFLOW_TIMEOUT,
+            ),
+            default_workflow=(
+                config.get("autoland", "default_workflow", fallback="").strip() or None
             ),
             dry_run=bool(getattr(args, "dry_run", False)),
             branch=getattr(args, "branch", None),
@@ -875,8 +879,15 @@ def wait_for_workflow(
 # ---------------------------------------------------------------------------
 
 
-def generate_default_plan(stack: list[StackEntry]) -> list[PlanStep]:
-    return [LandStep(entry_index=i) for i in range(len(stack))]
+def generate_default_plan(
+    stack: list[StackEntry], default_workflow: str | None = None
+) -> list[PlanStep]:
+    plan: list[PlanStep] = [LandStep(entry_index=i) for i in range(len(stack))]
+    # If a default workflow is configured, wait for it once the whole stack has
+    # landed. The user can still edit or remove this step in interactive mode.
+    if default_workflow:
+        plan.append(WorkflowStep(workflow=default_workflow))
+    return plan
 
 
 def format_plan_for_editor(stack: list[StackEntry], plan: list[PlanStep]) -> str:
@@ -945,9 +956,13 @@ def parse_plan(text: str, stack: list[StackEntry]) -> list[PlanStep]:
     return steps
 
 
-def edit_plan_interactive(stack: list[StackEntry]) -> list[PlanStep]:
+def edit_plan_interactive(
+    stack: list[StackEntry], default_workflow: str | None = None
+) -> list[PlanStep]:
     """Open the default plan in $EDITOR and return the parsed result."""
-    plan_text = format_plan_for_editor(stack, generate_default_plan(stack))
+    plan_text = format_plan_for_editor(
+        stack, generate_default_plan(stack, default_workflow)
+    )
     editor = os.environ.get("EDITOR", "vim")
 
     with tempfile.NamedTemporaryFile(
@@ -1684,7 +1699,7 @@ def _run_fresh(common: cli.CommonArgs, opts: AutolandOptions) -> None:
     enrich_stack(stack)
 
     plan = (
-        edit_plan_interactive(stack)
+        edit_plan_interactive(stack, opts.default_workflow)
         if opts.interactive
         else generate_default_plan(stack)
     )

--- a/src/stack_pr/autoland.py
+++ b/src/stack_pr/autoland.py
@@ -1,0 +1,1758 @@
+# stack-pr autoland: land a whole stack through the GitHub merge queue.
+#
+# This module holds the full autoland engine. cli.py only wires up the
+# subparser and dispatches into `run_autoland` to keep cli.py small.
+#
+# Repo-specific behavior (which CI checks gate a merge, poll intervals,
+# retry counts, deploy timeouts, and whether the repo uses a merge queue at
+# all) is externalized to the `[autoland]` config section and command-line
+# flags, so a repo can reproduce its workflow with configuration alone.
+from __future__ import annotations
+
+import argparse
+import configparser
+import contextlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Union
+
+# FIXME(stack-pr): autoland reaches into cli for shared building blocks
+# (get_stack, command_submit, last) and reimplements a retrying subprocess
+# wrapper below (run/gh_json) that overlaps with stack_pr.shell_commands. These
+# should be consolidated into a shared module (e.g. stack_pr.git / a common
+# helpers module) usable by every subcommand, rather than importing from cli.
+from stack_pr import cli
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via [autoland] config or flags)
+# ---------------------------------------------------------------------------
+
+DEFAULT_POLL_INTERVAL = 120  # seconds
+DEFAULT_MAX_CHECK_RETRIES = 3
+DEFAULT_MAX_QUEUE_RETRIES = 3
+DEFAULT_DEPLOY_TIMEOUT = 10800  # 3 hours
+DEFAULT_MERGE_TIMEOUT = 3600  # 60 minutes
+
+# ---------------------------------------------------------------------------
+# Output: use rich when available, fall back to plain text otherwise.
+# ---------------------------------------------------------------------------
+
+# Matches rich-style markup tags like [bold], [/dim], [red bold] so the
+# plain-text console can strip them.
+_RE_MARKUP = re.compile(r"\[/?[a-z][a-z0-9 _]*\]")
+
+
+class _PlainConsole:
+    """Minimal stand-in for rich.Console that strips markup."""
+
+    def print(self, *args: object, **_kwargs: object) -> None:
+        print(*[_RE_MARKUP.sub("", str(a)) for a in args])
+
+    def input(self, prompt: object = "") -> str:
+        return input(_RE_MARKUP.sub("", str(prompt)))
+
+
+try:
+    from rich.console import Console
+    from rich.table import Table
+    from rich.text import Text
+
+    HAVE_RICH = True
+except ImportError:  # pragma: no cover - exercised only without the extra
+    Console = _PlainConsole  # type: ignore[assignment,misc]
+    Table = None  # type: ignore[assignment,misc]
+    Text = None  # type: ignore[assignment,misc]
+    HAVE_RICH = False
+
+console = Console()
+
+
+# ---------------------------------------------------------------------------
+# Options resolved by precedence: command-line flag, then config, then default
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AutolandOptions:
+    merge_queue: bool
+    required_checks: list[str]
+    poll_interval: int
+    max_check_retries: int
+    max_queue_retries: int
+    merge_timeout: int
+    deploy_timeout: int
+    dry_run: bool
+    branch: str | None
+    interactive: bool
+    resume: bool
+    state_file: Path | None
+    always_cleanup: bool
+
+    @classmethod
+    def from_config_and_args(
+        cls, config: configparser.ConfigParser, args: argparse.Namespace
+    ) -> AutolandOptions:
+        def _int(flag_val: int | None, key: str, default: int) -> int:
+            if flag_val is not None:
+                return flag_val
+            return config.getint("autoland", key, fallback=default)
+
+        raw_checks = config.get("autoland", "required_checks", fallback="")
+        required_checks = [c.strip() for c in raw_checks.split(",") if c.strip()]
+
+        state_file = getattr(args, "state_file", None)
+        return cls(
+            merge_queue=config.getboolean(
+                "autoland", "merge_queue", fallback=False
+            ),
+            required_checks=required_checks,
+            poll_interval=_int(
+                getattr(args, "poll_interval", None),
+                "poll_interval",
+                DEFAULT_POLL_INTERVAL,
+            ),
+            max_check_retries=_int(
+                getattr(args, "max_check_retries", None),
+                "max_check_retries",
+                DEFAULT_MAX_CHECK_RETRIES,
+            ),
+            max_queue_retries=_int(
+                getattr(args, "max_queue_retries", None),
+                "max_queue_retries",
+                DEFAULT_MAX_QUEUE_RETRIES,
+            ),
+            merge_timeout=config.getint(
+                "autoland", "merge_timeout", fallback=DEFAULT_MERGE_TIMEOUT
+            ),
+            deploy_timeout=_int(
+                getattr(args, "deploy_timeout", None),
+                "deploy_timeout",
+                DEFAULT_DEPLOY_TIMEOUT,
+            ),
+            dry_run=bool(getattr(args, "dry_run", False)),
+            branch=getattr(args, "branch", None),
+            interactive=bool(getattr(args, "interactive", False)),
+            resume=bool(getattr(args, "resume", False)),
+            state_file=Path(state_file) if state_file else None,
+            always_cleanup=bool(getattr(args, "always_cleanup", False)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+class PRState(str, Enum):
+    PENDING = "pending"
+    WAITING_FOR_APPROVAL = "waiting_for_approval"
+    WAITING_FOR_CHECKS = "waiting_for_checks"
+    IN_MERGE_QUEUE = "in_merge_queue"
+    WAITING_FOR_DEPLOY = "waiting_for_deploy"
+    MERGED = "merged"
+    FAILED = "failed"
+
+
+@dataclass
+class StackEntry:
+    """One PR in the stack (bottom = index 0)."""
+
+    pr_url: str
+    pr_number: int
+    branch: str
+    title: str = ""
+    review_decision: str = ""  # APPROVED, REVIEW_REQUIRED, CHANGES_REQUESTED, ""
+    state: PRState = PRState.PENDING
+    check_retries: int = 0
+    queue_retries: int = 0
+    error_message: str = ""
+
+    @property
+    def is_approved(self) -> bool:
+        return self.review_decision == "APPROVED"
+
+
+@dataclass
+class LandStep:
+    """Land the next PR in the stack through the merge queue."""
+
+    entry_index: int
+
+
+@dataclass
+class DeployStep:
+    """Wait for a deploy workflow to succeed with the landed code."""
+
+    workflow: str
+    state: str = "pending"  # pending, waiting, succeeded, failed
+    error_message: str = ""
+
+
+@dataclass
+class ConfirmStep:
+    """Pause until the user types ``y``/``Y`` and presses Enter to continue."""
+
+    message: str = "Confirm to continue"
+    confirmed: bool = False
+
+
+PlanStep = Union[LandStep, DeployStep, ConfirmStep]
+
+
+@dataclass
+class LandingContext:
+    """Mutable state for the landing run."""
+
+    stack: list[StackEntry] = field(default_factory=list)
+    plan: list[PlanStep] = field(default_factory=list)
+    current_step: int = 0
+    current_index: int = 0  # index into stack for the active land step
+    aborted: bool = False
+    abort_reason: str = ""
+    last_landed_sha: str = ""  # origin/<target> HEAD after the last merge
+
+
+# ---------------------------------------------------------------------------
+# State persistence (checkpoint / resume)
+# ---------------------------------------------------------------------------
+
+STATE_VERSION = 1
+
+_STEP_TYPES = {LandStep: "land", DeployStep: "deploy", ConfirmStep: "confirm"}
+
+
+def _deserialize_entry(data: dict) -> StackEntry:
+    return StackEntry(
+        pr_url=data["pr_url"],
+        pr_number=data["pr_number"],
+        branch=data["branch"],
+        title=data.get("title", ""),
+        review_decision=data.get("review_decision", ""),
+        state=PRState(data.get("state", "pending")),
+        check_retries=data.get("check_retries", 0),
+        queue_retries=data.get("queue_retries", 0),
+        error_message=data.get("error_message", ""),
+    )
+
+
+def _serialize_step(step: PlanStep) -> dict:
+    # dataclasses.asdict gives the fields; tag the type for deserialization.
+    return {"type": _STEP_TYPES[type(step)], **asdict(step)}
+
+
+def _deserialize_step(data: dict) -> PlanStep:
+    fields = {k: v for k, v in data.items() if k != "type"}
+    if data["type"] == "land":
+        return LandStep(**fields)
+    if data["type"] == "deploy":
+        return DeployStep(**fields)
+    return ConfirmStep(**fields)
+
+
+@dataclass
+class AutolandCheckpointer:
+    """Persists and restores landing state for crash-safe ``--resume``."""
+
+    path: Path
+    branch: str
+    base: str
+
+    @staticmethod
+    def default_path(branch: str) -> Path:
+        slug = re.sub(r"[^a-zA-Z0-9_-]", "_", branch)
+        return Path.home() / ".stack-pr" / "autoland" / f"{slug}.json"
+
+    def save(self, ctx: LandingContext) -> None:
+        """Atomically write a checkpoint of *ctx* to the state file."""
+        data = {
+            "version": STATE_VERSION,
+            "branch": self.branch,
+            "base": self.base,
+            "current_step": ctx.current_step,
+            "last_landed_sha": ctx.last_landed_sha,
+            "stack": [asdict(e) for e in ctx.stack],
+            "plan": [_serialize_step(s) for s in ctx.plan],
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2) + "\n")
+        tmp.rename(self.path)
+
+    def delete(self) -> None:
+        self.path.unlink(missing_ok=True)
+
+    @classmethod
+    def load(cls, path: Path) -> tuple[AutolandCheckpointer, LandingContext]:
+        """Load a checkpoint; returns the checkpointer and restored context."""
+        data = json.loads(path.read_text())
+        if data.get("version") != STATE_VERSION:
+            raise ValueError(f"Unsupported state file version: {data.get('version')}")
+        ctx = LandingContext(
+            stack=[_deserialize_entry(e) for e in data["stack"]],
+            plan=[_deserialize_step(s) for s in data["plan"]],
+            current_step=data.get("current_step", 0),
+            last_landed_sha=data.get("last_landed_sha", ""),
+        )
+        return cls(path=path, branch=data["branch"], base=data["base"]), ctx
+
+
+def _current_branch() -> str:
+    return run(["git", "rev-parse", "--abbrev-ref", "HEAD"], quiet=True).stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Sleep / wake resilience
+# ---------------------------------------------------------------------------
+
+_SLEEP_DETECTION_THRESHOLD = 30
+
+
+def resilient_sleep(seconds: int) -> float:
+    """Sleep, detecting system sleep/wake; wait for network after a wake."""
+    start = time.monotonic()
+    time.sleep(seconds)
+    actual = time.monotonic() - start
+
+    sleep_gap = max(0.0, actual - seconds - _SLEEP_DETECTION_THRESHOLD)
+    if sleep_gap > 0:
+        gap_min = int(sleep_gap) // 60
+        gap_sec = int(sleep_gap) % 60
+        console.print(
+            f"\n[yellow]System sleep detected — machine was suspended "
+            f"~{gap_min}m{gap_sec}s. Waiting for network...[/yellow]"
+        )
+        _wait_for_network()
+        console.print("[green]Network is back. Resuming.[/green]\n")
+
+    return sleep_gap
+
+
+def _wait_for_network(max_wait: int = 120, interval: int = 5) -> None:
+    """Block until ``gh api user`` succeeds or *max_wait* seconds elapse."""
+    deadline = time.monotonic() + max_wait
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["gh", "api", "user", "--jq", ".login"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            if result.returncode == 0:
+                return
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+        time.sleep(interval)
+    console.print(
+        f"[yellow]Warning: network still unreachable after {max_wait}s — "
+        "continuing anyway[/yellow]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shell helpers (with transient-failure retries)
+# ---------------------------------------------------------------------------
+
+_MAX_RETRIES = 2
+_RETRY_DELAY = 10
+
+
+def run(
+    cmd: list[str],
+    *,
+    check: bool = True,
+    capture: bool = True,
+    quiet: bool = False,
+    input_data: bytes | None = None,
+    retries: int = _MAX_RETRIES,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, retrying likely-transient failures.
+
+    Commands run in the current working directory (autoland chdirs into a
+    temporary worktree when ``--branch`` is used).
+    """
+    last_err: Exception | None = None
+
+    for attempt in range(retries + 1):
+        if attempt > 0:
+            if not quiet:
+                console.print(
+                    f"[yellow]  retry {attempt}/{retries} in {_RETRY_DELAY}s..."
+                    "[/yellow]"
+                )
+            time.sleep(_RETRY_DELAY)
+
+        if not quiet:
+            suffix = "" if attempt == 0 else f"  (attempt {attempt + 1})"
+            console.print(f"[dim]$ {' '.join(cmd)}{suffix}[/dim]")
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=capture,
+                text=True,
+                input=input_data.decode() if input_data else None,
+                timeout=300,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            last_err = RuntimeError(f"Command error: {exc}")
+            continue
+
+        if check and result.returncode != 0:
+            stderr = result.stderr.strip() if result.stderr else ""
+            last_err = RuntimeError(
+                f"Command failed ({result.returncode}): {' '.join(cmd)}\n{stderr}"
+            )
+            # Only retry failures that look transient (network), not logical
+            # failures like a merge conflict.
+            if _is_likely_transient(result):
+                continue
+            raise last_err
+
+        return result
+
+    assert last_err is not None
+    raise last_err
+
+
+def _is_likely_transient(result: subprocess.CompletedProcess[str]) -> bool:
+    indicators = [
+        "could not resolve",
+        "connection refused",
+        "connection reset",
+        "timed out",
+        "timeout",
+        "network is unreachable",
+        "temporary failure",
+        "ssl",
+        "eof",
+        "broken pipe",
+        "http 5",  # 500, 502, 503, etc.
+        "server error",
+        "try again",
+        "unavailable",
+    ]
+    text = ((result.stderr or "") + (result.stdout or "")).lower()
+    return any(ind in text for ind in indicators)
+
+
+def gh_json(cmd: list[str]) -> dict | list:
+    """Run a gh command and parse JSON output."""
+    result = run(["gh", *cmd], quiet=True)
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# GitHub access — every `gh` / `gh api` call autoland makes lives here.
+# ---------------------------------------------------------------------------
+
+_MERGE_QUEUE_ENTRY_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      mergeQueueEntry { id state }
+    }
+  }
+}
+""".strip()
+
+
+@dataclass
+class MergeQueuePollResult:
+    merged: bool = False
+    booted: bool = False
+    error: str = ""
+
+
+class GitHub:
+    """Wrapper over the ``gh`` CLI for the PR / merge-queue calls autoland needs."""
+
+    def __init__(self) -> None:
+        self._owner_repo: tuple[str, str] | None = None
+
+    def owner_repo(self) -> tuple[str, str]:
+        if self._owner_repo is None:
+            data = gh_json(["repo", "view", "--json", "owner,name"])
+            assert isinstance(data, dict)
+            self._owner_repo = (data["owner"]["login"], data["name"])
+        return self._owner_repo
+
+    def _pr_view(self, pr_number: int, fields: str) -> dict:
+        data = gh_json(["pr", "view", str(pr_number), "--json", fields])
+        assert isinstance(data, dict)
+        return data
+
+    def pr_state(self, pr_number: int) -> str:
+        return self._pr_view(pr_number, "state").get("state", "OPEN")
+
+    def merge_state(self, pr_number: int) -> dict:
+        return self._pr_view(pr_number, "state,mergeStateStatus,mergeable")
+
+    def review_decision(self, pr_number: int) -> str:
+        return self._pr_view(pr_number, "reviewDecision").get("reviewDecision", "")
+
+    def summary(self, pr_number: int) -> dict:
+        return self._pr_view(pr_number, "title,state,reviewDecision")
+
+    def checks(self, pr_number: int) -> list[dict]:
+        data = gh_json(
+            ["pr", "checks", str(pr_number), "--json", "name,state,bucket,link,workflow"]
+        )
+        assert isinstance(data, list)
+        return data
+
+    def rerun_failed(self, run_ids: list[int]) -> None:
+        for run_id in dict.fromkeys(run_ids):  # de-dup, preserve order
+            try:
+                run(["gh", "run", "rerun", str(run_id), "--failed"], quiet=False)
+            except RuntimeError as e:
+                console.print(
+                    f"[yellow]Warning: could not rerun {run_id}: {e}[/yellow]"
+                )
+
+    def in_merge_queue(self, pr_number: int) -> bool:
+        """Whether the PR currently has an active merge-queue entry (GraphQL)."""
+        try:
+            owner, repo = self.owner_repo()
+            result = run(
+                [
+                    "gh", "api", "graphql",
+                    "-F", f"owner={owner}",
+                    "-F", f"repo={repo}",
+                    "-F", f"number={pr_number}",
+                    "-f", f"query={_MERGE_QUEUE_ENTRY_QUERY}",
+                ],
+                quiet=True,
+            )
+            entry = (
+                json.loads(result.stdout)
+                .get("data", {})
+                .get("repository", {})
+                .get("pullRequest", {})
+                .get("mergeQueueEntry")
+            )
+            return entry is not None
+        except (RuntimeError, json.JSONDecodeError):
+            return False
+
+    def enqueue(self, pr_number: int) -> None:
+        run(["gh", "pr", "merge", str(pr_number), "--squash"], quiet=False)
+
+    def poll_merge(self, pr_number: int) -> MergeQueuePollResult:
+        state = self.pr_state(pr_number)
+        if state == "MERGED":
+            return MergeQueuePollResult(merged=True)
+        if state == "CLOSED":
+            return MergeQueuePollResult(error="PR was closed")
+        if state == "OPEN" and not self.in_merge_queue(pr_number):
+            return MergeQueuePollResult(booted=True)
+        return MergeQueuePollResult()
+
+    def workflow_runs(self, workflow: str, branch: str) -> list[dict]:
+        data = gh_json(
+            [
+                "run", "list",
+                "--workflow", workflow,
+                "--branch", branch,
+                "--json", "headSha,status,conclusion",
+                "--limit", "10",
+            ]
+        )
+        assert isinstance(data, list)
+        return data
+
+
+github = GitHub()
+
+
+# ---------------------------------------------------------------------------
+# Worktree management
+# ---------------------------------------------------------------------------
+
+
+class Worktree:
+    """A temporary git worktree autoland operates in (for ``--branch``).
+
+    ``create`` checks the branch out in a throwaway worktree and chdirs into
+    it; ``remove`` restores the original directory and deletes the worktree.
+    ``announce_preserved`` is used instead of ``remove`` to keep it around for
+    debugging after a failure.
+    """
+
+    def __init__(self, branch: str) -> None:
+        self.branch = branch
+        self.path: Path | None = None
+        self._orig_cwd: str | None = None
+
+    def create(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix="autoland-")
+        worktree_dir = str(Path(tmpdir) / "repo")
+        console.print(
+            f"[bold]Creating temporary worktree for [cyan]{self.branch}[/cyan] "
+            f"at {worktree_dir}[/bold]"
+        )
+        subprocess.run(
+            ["git", "worktree", "add", "-f", worktree_dir, self.branch],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.path = Path(worktree_dir)
+        self._orig_cwd = str(Path.cwd())
+        os.chdir(worktree_dir)
+
+    def remove(self) -> None:
+        if self.path is None:
+            return
+        if self._orig_cwd:
+            os.chdir(self._orig_cwd)
+            self._orig_cwd = None
+        console.print(f"\n[dim]Cleaning up worktree at {self.path}...[/dim]")
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(self.path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        shutil.rmtree(self.path.parent, ignore_errors=True)
+        self.path = None
+
+    def announce_preserved(self) -> None:
+        if self.path is None:
+            return
+        console.print(
+            f"\n[bold yellow]Worktree preserved at: "
+            f"[cyan]{self.path}[/cyan][/bold yellow]"
+        )
+        console.print(
+            "[dim]To clean up manually: "
+            f"git worktree remove --force {self.path}[/dim]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stack discovery (reuses stack-pr's get_stack)
+# ---------------------------------------------------------------------------
+
+
+def discover_stack(common: cli.CommonArgs) -> list[StackEntry]:
+    """Discover the stack via stack-pr's own parser, bottom-to-top order."""
+    entries: list[StackEntry] = []
+    for e in cli.get_stack(
+        base=common.base, head=common.head, verbose=common.verbose
+    ):
+        if not e.has_pr():
+            continue  # commit not submitted yet — skip
+        pr_number = int(cli.last(e.pr))
+        entries.append(
+            StackEntry(pr_url=e.pr, pr_number=pr_number, branch=e.head)
+        )
+    return entries
+
+
+def enrich_stack(stack: list[StackEntry]) -> None:
+    """Fetch PR titles, review status, and current state from GitHub."""
+    for entry in stack:
+        try:
+            data = github.summary(entry.pr_number)
+            entry.title = data.get("title", "")
+            entry.review_decision = data.get("reviewDecision", "")
+            if data.get("state") == "MERGED":
+                entry.state = PRState.MERGED
+        except RuntimeError:
+            entry.title = "(could not fetch)"
+
+
+# ---------------------------------------------------------------------------
+# Check monitoring
+# ---------------------------------------------------------------------------
+
+RE_RUN_ID_FROM_LINK = re.compile(r"/actions/runs/(\d+)")
+
+
+def _extract_run_id(link: str) -> int | None:
+    m = RE_RUN_ID_FROM_LINK.search(link)
+    return int(m.group(1)) if m else None
+
+
+class CheckStatus(Enum):
+    ALL_PASSING = "all_passing"
+    PENDING = "pending"
+    FAILED = "failed"
+    NOT_STARTED = "not_started"
+
+
+@dataclass
+class CheckResult:
+    status: CheckStatus
+    failed_runs: list[int] = field(default_factory=list)
+    failed_names: list[str] = field(default_factory=list)
+    summary: str = ""
+
+
+def evaluate_checks(checks: list[dict], required_checks: list[str]) -> CheckResult:
+    """Evaluate a PR's check runs.
+
+    If *required_checks* is non-empty, gate on exactly those named checks.
+    Otherwise gate on all reported checks that aren't being skipped.
+    """
+    if required_checks:
+        check_map = {
+            c.get("name", ""): c
+            for c in checks
+            if c.get("name", "") in required_checks
+        }
+        missing = [n for n in required_checks if n not in check_map]
+        if missing:
+            return CheckResult(
+                status=CheckStatus.NOT_STARTED,
+                summary=f"Waiting for checks to start: {', '.join(missing)}",
+            )
+        names = list(required_checks)
+    else:
+        check_map = {}
+        for c in checks:
+            if (c.get("bucket") or "").lower() == "skipping":
+                continue
+            check_map[c.get("name", "")] = c
+        if not check_map:
+            return CheckResult(
+                status=CheckStatus.NOT_STARTED,
+                summary="Waiting for checks to start",
+            )
+        names = list(check_map.keys())
+
+    failed_runs: list[int] = []
+    failed_names: list[str] = []
+    any_pending = False
+
+    for name in names:
+        bucket = (check_map[name].get("bucket") or "").lower()
+        if bucket == "pass":
+            continue
+        if bucket in ("fail", "cancel"):
+            run_id = _extract_run_id(check_map[name].get("link", ""))
+            if run_id:
+                failed_runs.append(run_id)
+            failed_names.append(name)
+        else:
+            # pending, skipping, or unknown -> still waiting
+            any_pending = True
+
+    if failed_names:
+        return CheckResult(
+            status=CheckStatus.FAILED,
+            failed_runs=failed_runs,
+            failed_names=failed_names,
+            summary=f"Failed: {', '.join(failed_names)}",
+        )
+    if any_pending:
+        return CheckResult(status=CheckStatus.PENDING, summary="Checks in progress...")
+    return CheckResult(status=CheckStatus.ALL_PASSING, summary="All checks passing")
+
+
+# ---------------------------------------------------------------------------
+# Post-merge rebase + resubmit (reuses stack-pr submit)
+# ---------------------------------------------------------------------------
+
+
+def rebase_and_resubmit(common: cli.CommonArgs) -> None:
+    """After a merge, rebase the local stack on the target and re-submit."""
+    console.print(
+        f"\n[bold]Rebasing stack on {common.remote}/{common.target}...[/bold]"
+    )
+    run(["git", "fetch", common.remote, common.target], quiet=False)
+    # Rebase the current branch (don't name it) so this works even when the
+    # branch is checked out in another worktree.
+    run(["git", "rebase", f"{common.remote}/{common.target}"], quiet=False)
+
+    console.print("[bold]Re-submitting stack...[/bold]")
+    cli.command_submit(
+        common, draft=False, reviewer="", keep_body=True, draft_bitmask=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deploy checkpoint polling
+# ---------------------------------------------------------------------------
+
+
+def _refresh_last_landed_sha(ctx: LandingContext, common: cli.CommonArgs) -> None:
+    try:
+        run(["git", "fetch", common.remote, common.target], quiet=True)
+        result = run(
+            ["git", "rev-parse", f"{common.remote}/{common.target}"], quiet=True
+        )
+        ctx.last_landed_sha = result.stdout.strip()
+    except RuntimeError:
+        pass  # non-critical; will retry when needed
+
+
+def _is_ancestor(ancestor: str, descendant: str) -> bool:
+    result = run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        check=False,
+        quiet=True,
+    )
+    return result.returncode == 0
+
+
+def wait_for_deploy(
+    step: DeployStep,
+    *,
+    opts: AutolandOptions,
+    common: cli.CommonArgs,
+    ctx: LandingContext,
+) -> bool:
+    """Wait for a deploy workflow to complete with code at or after the landed SHA."""
+    target_sha = ctx.last_landed_sha
+    step.state = "waiting"
+    console.print(
+        f"\n[bold blue]Waiting for deploy: {step.workflow}[/bold blue]"
+        f"\n[dim]Target SHA: {target_sha[:12]}[/dim]"
+    )
+
+    awake_elapsed = 0.0
+    while True:
+        if ctx.aborted:
+            return False
+        if awake_elapsed > opts.deploy_timeout:
+            step.state = "failed"
+            step.error_message = (
+                f"Deploy timed out after {opts.deploy_timeout / 3600:.0f}h"
+            )
+            return False
+
+        try:
+            data = github.workflow_runs(step.workflow, common.target)
+        except RuntimeError as e:
+            console.print(f"[yellow]Warning: could not poll deploy: {e}[/yellow]")
+            resilient_sleep(opts.poll_interval)
+            awake_elapsed += opts.poll_interval
+            continue
+
+        for wf_run in data:
+            if wf_run.get("status") != "completed":
+                continue
+            if wf_run.get("conclusion") != "success":
+                continue
+            run_sha = wf_run.get("headSha", "")
+            if not run_sha:
+                continue
+            if run_sha == target_sha or _is_ancestor(target_sha, run_sha):
+                step.state = "succeeded"
+                step.error_message = ""
+                console.print(
+                    f"\n[bold green]Deploy {step.workflow} completed "
+                    f"with SHA {run_sha[:12]}[/bold green]"
+                )
+                return True
+
+        mins = int(awake_elapsed) // 60
+        step.error_message = f"Waiting for deploy ({mins}m elapsed)..."
+        console.print(
+            f"[dim]Deploy {step.workflow}: waiting ({mins}m) — "
+            f"polling in {opts.poll_interval}s[/dim]"
+        )
+        resilient_sleep(opts.poll_interval)
+        awake_elapsed += opts.poll_interval
+
+
+# ---------------------------------------------------------------------------
+# Interactive plan editing
+# ---------------------------------------------------------------------------
+
+
+def generate_default_plan(stack: list[StackEntry]) -> list[PlanStep]:
+    return [LandStep(entry_index=i) for i in range(len(stack))]
+
+
+def format_plan_for_editor(stack: list[StackEntry], plan: list[PlanStep]) -> str:
+    lines = [
+        "# Autoland plan — edit steps below.",
+        "# l             = land the next PR in the stack",
+        "# d <workflow>  = wait for deploy workflow to complete",
+        "# c <message>   = pause and wait for manual confirmation",
+        "#",
+        "# Lines starting with # are comments and are ignored.",
+        "# Blank lines are ignored.",
+        "#",
+    ]
+    for step in plan:
+        if isinstance(step, LandStep):
+            entry = stack[step.entry_index]
+            lines.append(f"l    # PR #{entry.pr_number}: {entry.title}")
+        elif isinstance(step, DeployStep):
+            lines.append(f"d {step.workflow}")
+        elif isinstance(step, ConfirmStep):
+            lines.append(f"c {step.message}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_plan(text: str, stack: list[StackEntry]) -> list[PlanStep]:
+    """Parse an edited plan back into steps. Raises ValueError if malformed."""
+    steps: list[PlanStep] = []
+    land_counter = 0
+
+    for line_num, raw_line in enumerate(text.splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if " #" in line:
+            line = line[: line.index(" #")].strip()
+
+        if line == "l":
+            if land_counter >= len(stack):
+                raise ValueError(
+                    f"Line {line_num}: too many 'l' steps — "
+                    f"only {len(stack)} PRs in stack"
+                )
+            steps.append(LandStep(entry_index=land_counter))
+            land_counter += 1
+        elif line.startswith("d "):
+            workflow = line[2:].strip()
+            if not workflow:
+                raise ValueError(
+                    f"Line {line_num}: 'd' requires a workflow name"
+                )
+            steps.append(DeployStep(workflow=workflow))
+        elif line == "c" or line.startswith("c "):
+            message = (
+                line[2:].strip() if line.startswith("c ") else "Confirm to continue"
+            )
+            steps.append(ConfirmStep(message=message))
+        else:
+            raise ValueError(f"Line {line_num}: unrecognized step: {raw_line!r}")
+
+    if land_counter != len(stack):
+        raise ValueError(
+            f"Plan has {land_counter} land steps but stack has "
+            f"{len(stack)} PRs — all PRs must be landed"
+        )
+    return steps
+
+
+def edit_plan_interactive(stack: list[StackEntry]) -> list[PlanStep]:
+    """Open the default plan in $EDITOR and return the parsed result."""
+    plan_text = format_plan_for_editor(stack, generate_default_plan(stack))
+    editor = os.environ.get("EDITOR", "vim")
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", prefix="autoland-plan-", delete=False
+    ) as f:
+        f.write(plan_text)
+        plan_file = f.name
+
+    try:
+        console.print(f"[bold]Opening plan in {editor}...[/bold]")
+        subprocess.run([editor, plan_file], check=True)
+        edited_text = Path(plan_file).read_text()
+
+        non_comment = [
+            ln.strip()
+            for ln in edited_text.splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        if not non_comment:
+            console.print("[yellow]Empty plan — aborting.[/yellow]")
+            sys.exit(0)
+
+        return parse_plan(edited_text, stack)
+    except ValueError as e:
+        console.print(f"[red]Invalid plan: {e}[/red]")
+        sys.exit(1)
+    except subprocess.CalledProcessError:
+        console.print(f"[red]Editor ({editor}) exited with an error.[/red]")
+        sys.exit(1)
+    finally:
+        Path(plan_file).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Status display
+# ---------------------------------------------------------------------------
+
+STATE_LABELS = {
+    PRState.PENDING: "Pending",
+    PRState.WAITING_FOR_APPROVAL: "Waiting for approval",
+    PRState.WAITING_FOR_CHECKS: "Waiting for checks",
+    PRState.IN_MERGE_QUEUE: "In merge queue",
+    PRState.WAITING_FOR_DEPLOY: "Waiting for deploy",
+    PRState.MERGED: "Merged",
+    PRState.FAILED: "Failed",
+}
+
+STATE_STYLES = {
+    PRState.PENDING: "dim",
+    PRState.WAITING_FOR_APPROVAL: "magenta",
+    PRState.WAITING_FOR_CHECKS: "yellow",
+    PRState.IN_MERGE_QUEUE: "cyan",
+    PRState.WAITING_FOR_DEPLOY: "blue",
+    PRState.MERGED: "green",
+    PRState.FAILED: "red bold",
+}
+
+_REVIEW_DECISION_DISPLAY = {
+    "APPROVED": ("Approved", "green"),
+    "REVIEW_REQUIRED": ("Review required", "magenta"),
+    "CHANGES_REQUESTED": ("Changes requested", "red"),
+}
+
+_DEPLOY_STEP_STYLES = {
+    "pending": ("Pending", "dim"),
+    "waiting": ("Waiting for deploy", "blue"),
+    "succeeded": ("Deploy complete", "green"),
+    "failed": ("Failed", "red bold"),
+}
+
+
+def render_status_table(ctx: LandingContext) -> Table:  # pragma: no cover
+    """Render plan progress as a rich table (rich-only path)."""
+    table = Table(title="Autoland Progress", show_header=False, show_lines=True)
+    table.add_column("Field", style="bold dim", width=14, no_wrap=True)
+    table.add_column("Value", min_width=40)
+
+    plan = ctx.plan or generate_default_plan(ctx.stack)
+    for step_idx, step in enumerate(plan):
+        if step_idx > 0:
+            table.add_section()
+        pointer = "->" if step_idx == ctx.current_step else " "
+
+        if isinstance(step, LandStep):
+            entry = ctx.stack[step.entry_index]
+            table.add_row(
+                f"{pointer} Step {step_idx + 1}/{len(plan)}",
+                Text(f"Land PR #{entry.pr_number}", style="bold"),
+            )
+            table.add_row("  Title", entry.title or "(untitled)")
+            status_text = STATE_LABELS.get(entry.state, str(entry.state))
+            if entry.error_message:
+                status_text += f"\n  {entry.error_message}"
+            table.add_row(
+                "  Status",
+                Text(status_text, style=STATE_STYLES.get(entry.state, "")),
+            )
+            table.add_row(
+                "  Retries",
+                f"CI {entry.check_retries} - MQ {entry.queue_retries}",
+            )
+        elif isinstance(step, DeployStep):
+            table.add_row(
+                f"{pointer} Step {step_idx + 1}/{len(plan)}",
+                Text("Deploy checkpoint", style="bold blue"),
+            )
+            table.add_row("  Workflow", step.workflow)
+            label, ds_style = _DEPLOY_STEP_STYLES.get(step.state, ("Pending", "dim"))
+            table.add_row("  Status", Text(label, style=ds_style))
+        elif isinstance(step, ConfirmStep):
+            table.add_row(
+                f"{pointer} Step {step_idx + 1}/{len(plan)}",
+                Text("Manual confirmation", style="bold yellow"),
+            )
+            table.add_row("  Message", step.message)
+
+    if ctx.aborted:
+        table.caption = f"ABORTED: {ctx.abort_reason}"
+    return table
+
+
+def render_status_plain(ctx: LandingContext) -> str:
+    lines = ["", "Autoland Progress", "================="]
+    plan = ctx.plan or generate_default_plan(ctx.stack)
+    for i, step in enumerate(plan):
+        cur = "->" if i == ctx.current_step else "  "
+        if isinstance(step, LandStep):
+            e = ctx.stack[step.entry_index]
+            lines.append(
+                f"{cur} [{i + 1}/{len(plan)}] Land PR #{e.pr_number}: "
+                f"{e.title or '(untitled)'}"
+            )
+            status = STATE_LABELS.get(e.state, str(e.state))
+            if e.error_message:
+                status += f" — {e.error_message}"
+            lines.append(f"      status: {status}")
+            lines.append(
+                f"      retries: CI {e.check_retries} / MQ {e.queue_retries}"
+            )
+        elif isinstance(step, DeployStep):
+            label, _ = _DEPLOY_STEP_STYLES.get(step.state, ("Pending", ""))
+            lines.append(
+                f"{cur} [{i + 1}/{len(plan)}] Deploy: {step.workflow} — {label}"
+            )
+        elif isinstance(step, ConfirmStep):
+            state = (
+                "confirmed"
+                if step.confirmed
+                else ("waiting" if i == ctx.current_step else "pending")
+            )
+            lines.append(
+                f"{cur} [{i + 1}/{len(plan)}] Confirm: {step.message} — {state}"
+            )
+    if ctx.aborted:
+        lines.append(f"ABORTED: {ctx.abort_reason}")
+    return "\n".join(lines)
+
+
+def print_status(ctx: LandingContext) -> None:
+    if HAVE_RICH:
+        console.print(render_status_table(ctx))
+    else:
+        console.print(render_status_plain(ctx))
+
+
+# ---------------------------------------------------------------------------
+# Landing logic
+# ---------------------------------------------------------------------------
+
+
+def _refresh_review(entry: StackEntry) -> None:
+    """Update the entry's review decision, tolerating a transient gh failure."""
+    with contextlib.suppress(RuntimeError):
+        entry.review_decision = github.review_decision(entry.pr_number)
+
+
+def wait_for_approval(
+    entry: StackEntry, *, opts: AutolandOptions, ctx: LandingContext
+) -> bool:
+    """Wait until the PR has required approvals. Returns False if aborted."""
+    pr_state = github.pr_state(entry.pr_number)
+    if pr_state == "MERGED":
+        entry.state = PRState.MERGED
+        return True
+    if pr_state == "CLOSED":
+        entry.state = PRState.FAILED
+        entry.error_message = "PR was closed"
+        return False
+
+    _refresh_review(entry)
+    if entry.is_approved:
+        return True
+
+    entry.state = PRState.WAITING_FOR_APPROVAL
+    label, _ = _REVIEW_DECISION_DISPLAY.get(entry.review_decision, ("not approved", ""))
+    entry.error_message = label
+    console.print(
+        f"[magenta]PR #{entry.pr_number} is not yet approved "
+        f"({entry.review_decision or 'REVIEW_REQUIRED'}). Waiting...[/magenta]"
+    )
+
+    while True:
+        if ctx.aborted:
+            return False
+        console.print(
+            f"[dim]PR #{entry.pr_number}: waiting for approval — "
+            f"polling in {opts.poll_interval}s[/dim]"
+        )
+        resilient_sleep(opts.poll_interval)
+
+        pr_state = github.pr_state(entry.pr_number)
+        if pr_state == "MERGED":
+            entry.state = PRState.MERGED
+            return True
+        if pr_state == "CLOSED":
+            entry.state = PRState.FAILED
+            entry.error_message = "PR was closed"
+            return False
+
+        _refresh_review(entry)
+        if entry.is_approved:
+            entry.error_message = ""
+            console.print(f"[green]PR #{entry.pr_number} is now approved[/green]")
+            return True
+        if entry.review_decision == "CHANGES_REQUESTED":
+            entry.error_message = "Changes requested — cannot proceed"
+            console.print(
+                f"[red]PR #{entry.pr_number} has changes requested. "
+                "Resolve review comments and re-request review.[/red]"
+            )
+
+
+def wait_for_checks(
+    entry: StackEntry, *, opts: AutolandOptions, ctx: LandingContext
+) -> bool:
+    """Wait for required checks to pass. Returns True on success."""
+    entry.state = PRState.WAITING_FOR_CHECKS
+
+    while True:
+        if ctx.aborted:
+            return False
+
+        pr_state = github.pr_state(entry.pr_number)
+        if pr_state == "MERGED":
+            entry.state = PRState.MERGED
+            return True
+        if pr_state == "CLOSED":
+            entry.state = PRState.FAILED
+            entry.error_message = "PR was closed"
+            return False
+
+        result = evaluate_checks(
+            github.checks(entry.pr_number), opts.required_checks
+        )
+        entry.error_message = result.summary
+
+        if result.status == CheckStatus.ALL_PASSING:
+            entry.error_message = "All checks passing"
+            return True
+
+        if result.status == CheckStatus.FAILED:
+            if entry.check_retries >= opts.max_check_retries:
+                entry.state = PRState.FAILED
+                entry.error_message = (
+                    f"Checks failed after {opts.max_check_retries} retries: "
+                    f"{', '.join(result.failed_names)}"
+                )
+                return False
+            entry.check_retries += 1
+            console.print(
+                f"[yellow]Rerunning failed checks "
+                f"(attempt {entry.check_retries}/{opts.max_check_retries}): "
+                f"{', '.join(result.failed_names)}[/yellow]"
+            )
+            github.rerun_failed(result.failed_runs)
+
+        console.print(
+            f"[dim]PR #{entry.pr_number}: {result.summary} — "
+            f"polling in {opts.poll_interval}s[/dim]"
+        )
+        resilient_sleep(opts.poll_interval)
+
+
+_MERGEABLE_STATES = {"CLEAN", "UNSTABLE", "HAS_HOOKS"}
+
+
+@dataclass
+class MergeableResult:
+    ready: bool = False
+    already_merged: bool = False
+    error: str = ""
+
+
+def wait_for_mergeable(
+    entry: StackEntry, *, opts: AutolandOptions, ctx: LandingContext
+) -> MergeableResult:
+    """Wait until GitHub reports the PR as mergeable."""
+    while True:
+        if ctx.aborted:
+            return MergeableResult(error="aborted")
+
+        data = github.merge_state(entry.pr_number)
+        pr_state = data.get("state", "")
+        merge_state = data.get("mergeStateStatus", "UNKNOWN")
+        mergeable = data.get("mergeable", "UNKNOWN")
+
+        if pr_state == "MERGED":
+            console.print(f"[green]PR #{entry.pr_number} is already merged[/green]")
+            return MergeableResult(ready=True, already_merged=True)
+        if pr_state == "CLOSED":
+            entry.state = PRState.FAILED
+            entry.error_message = "PR was closed"
+            return MergeableResult(error="PR was closed")
+
+        if merge_state in _MERGEABLE_STATES:
+            console.print(
+                f"[green]PR #{entry.pr_number} is mergeable "
+                f"(mergeStateStatus={merge_state})[/green]"
+            )
+            return MergeableResult(ready=True)
+
+        if mergeable == "CONFLICTING":
+            entry.error_message = "PR has merge conflicts — waiting for resolution"
+            console.print(
+                f"\n[bold red]PR #{entry.pr_number} has merge conflicts! "
+                "Resolve them on the PR branch and push; autoland will "
+                "resume automatically.[/bold red]"
+            )
+            resilient_sleep(opts.poll_interval)
+            continue
+
+        # UNKNOWN can also mean "already in the merge queue".
+        if merge_state == "UNKNOWN" and github.in_merge_queue(entry.pr_number):
+            console.print(
+                f"[cyan]PR #{entry.pr_number} is already in the merge queue — "
+                "skipping enqueue[/cyan]"
+            )
+            return MergeableResult(ready=True, already_merged=False)
+
+        entry.error_message = f"Waiting for mergeable state (currently {merge_state})"
+        console.print(
+            f"[dim]PR #{entry.pr_number}: mergeStateStatus={merge_state} — "
+            f"polling in {opts.poll_interval}s[/dim]"
+        )
+        resilient_sleep(opts.poll_interval)
+
+
+def _rewait_after_retry(
+    entry: StackEntry, *, opts: AutolandOptions, ctx: LandingContext
+) -> bool:
+    """Re-verify approval and checks before a queue retry."""
+    if not wait_for_approval(entry, opts=opts, ctx=ctx):
+        return False
+    entry.check_retries = 0
+    return wait_for_checks(entry, opts=opts, ctx=ctx)
+
+
+def enqueue_and_wait(
+    entry: StackEntry, *, opts: AutolandOptions, ctx: LandingContext
+) -> bool:
+    """Add the PR to the merge queue and wait for it to merge."""
+    while True:
+        if ctx.aborted:
+            return False
+
+        mergeable_result = wait_for_mergeable(entry, opts=opts, ctx=ctx)
+        if not mergeable_result.ready:
+            return False
+        if mergeable_result.already_merged:
+            entry.state = PRState.MERGED
+            entry.error_message = ""
+            console.print(
+                f"\n[bold green]PR #{entry.pr_number} already merged![/bold green]"
+            )
+            return True
+
+        entry.state = PRState.IN_MERGE_QUEUE
+        entry.error_message = "Adding to merge queue..."
+        console.print(
+            f"\n[bold cyan]Adding PR #{entry.pr_number} to merge queue[/bold cyan]"
+        )
+
+        try:
+            github.enqueue(entry.pr_number)
+        except RuntimeError as e:
+            entry.error_message = f"Failed to enqueue: {e}"
+            console.print(f"[red]Failed to add to merge queue: {e}[/red]")
+            if entry.queue_retries >= opts.max_queue_retries:
+                entry.state = PRState.FAILED
+                entry.error_message = (
+                    f"Failed to enqueue after {opts.max_queue_retries} attempts"
+                )
+                return False
+            entry.queue_retries += 1
+            if not _rewait_after_retry(entry, opts=opts, ctx=ctx):
+                return False
+            continue
+
+        entry.error_message = "Waiting in merge queue..."
+        awake_elapsed = 0.0
+        while True:
+            if ctx.aborted:
+                return False
+            if awake_elapsed > opts.merge_timeout:
+                entry.state = PRState.FAILED
+                entry.error_message = "Timed out waiting for merge queue"
+                return False
+
+            poll = github.poll_merge(entry.pr_number)
+            if poll.merged:
+                entry.state = PRState.MERGED
+                entry.error_message = ""
+                console.print(
+                    f"\n[bold green]PR #{entry.pr_number} merged![/bold green]"
+                )
+                return True
+            if poll.error:
+                entry.state = PRState.FAILED
+                entry.error_message = poll.error
+                return False
+            if poll.booted:
+                console.print(
+                    f"\n[yellow]PR #{entry.pr_number} was booted from the "
+                    "merge queue[/yellow]"
+                )
+                if entry.queue_retries >= opts.max_queue_retries:
+                    entry.state = PRState.FAILED
+                    entry.error_message = (
+                        f"Booted from queue {opts.max_queue_retries} times, giving up"
+                    )
+                    return False
+                entry.queue_retries += 1
+                if not _rewait_after_retry(entry, opts=opts, ctx=ctx):
+                    return False
+                break  # re-enqueue in outer loop
+
+            mins = int(awake_elapsed) // 60
+            entry.error_message = f"In merge queue ({mins}m elapsed)..."
+            console.print(
+                f"[dim]PR #{entry.pr_number}: in merge queue ({mins}m) — "
+                f"polling in {opts.poll_interval}s[/dim]"
+            )
+            resilient_sleep(opts.poll_interval)
+            awake_elapsed += opts.poll_interval
+
+
+def execute_plan(
+    ctx: LandingContext,
+    common: cli.CommonArgs,
+    opts: AutolandOptions,
+    checkpointer: AutolandCheckpointer,
+) -> bool:
+    """Execute the landing plan from ctx.current_step. Returns True on success."""
+    for step_idx in range(ctx.current_step, len(ctx.plan)):
+        step = ctx.plan[step_idx]
+        ctx.current_step = step_idx
+        checkpointer.save(ctx)
+
+        if isinstance(step, LandStep):
+            entry = ctx.stack[step.entry_index]
+            ctx.current_index = step.entry_index
+
+            if entry.state == PRState.MERGED:
+                console.print(
+                    f"\n[green]PR #{entry.pr_number} already merged, skipping[/green]"
+                )
+                _refresh_last_landed_sha(ctx, common)
+                continue
+
+            console.print(
+                f"\n{'=' * 60}\n[bold]Step {step_idx + 1}/{len(ctx.plan)}: "
+                f"Landing PR #{entry.pr_number} — {entry.title}[/bold]\n{'=' * 60}"
+            )
+
+            if not wait_for_approval(entry, opts=opts, ctx=ctx):
+                return _abort(
+                    ctx, checkpointer,
+                    f"PR #{entry.pr_number} approval wait was aborted",
+                )
+
+            if entry.state == PRState.MERGED:
+                _refresh_last_landed_sha(ctx, common)
+            else:
+                if not wait_for_checks(entry, opts=opts, ctx=ctx):
+                    return _abort(
+                        ctx, checkpointer,
+                        f"PR #{entry.pr_number} checks failed after retries",
+                    )
+
+                if entry.state == PRState.MERGED:
+                    _refresh_last_landed_sha(ctx, common)
+                else:
+                    if not enqueue_and_wait(entry, opts=opts, ctx=ctx):
+                        return _abort(
+                            ctx, checkpointer,
+                            f"PR #{entry.pr_number} failed to merge",
+                        )
+                    _refresh_last_landed_sha(ctx, common)
+
+            has_more_land_steps = any(
+                isinstance(s, LandStep) for s in ctx.plan[step_idx + 1 :]
+            )
+            if has_more_land_steps:
+                try:
+                    rebase_and_resubmit(common)
+                except Exception as e:  # noqa: BLE001 - report any resubmit failure
+                    return _abort(
+                        ctx, checkpointer,
+                        f"Rebase failed after merging #{entry.pr_number}: {e}",
+                    )
+
+        elif isinstance(step, DeployStep):
+            console.print(
+                f"\n{'=' * 60}\n[bold]Step {step_idx + 1}/{len(ctx.plan)}: "
+                f"Deploy checkpoint — {step.workflow}[/bold]\n{'=' * 60}"
+            )
+            if not ctx.last_landed_sha:
+                _refresh_last_landed_sha(ctx, common)
+            if not wait_for_deploy(step, opts=opts, common=common, ctx=ctx):
+                return _abort(
+                    ctx, checkpointer,
+                    f"Deploy {step.workflow} failed or timed out",
+                )
+
+        elif isinstance(step, ConfirmStep):
+            if step.confirmed:
+                continue
+            console.print(
+                f"\n{'=' * 60}\n[bold yellow]Step {step_idx + 1}/{len(ctx.plan)}: "
+                f"Manual confirmation required[/bold yellow]\n{'=' * 60}\n"
+                f"\n[bold]{step.message}[/bold]\n"
+            )
+            while True:
+                try:
+                    answer = console.input(
+                        "[yellow]Type y/Y then Enter to continue "
+                        "(Ctrl+C to abort): [/yellow]"
+                    ).strip()
+                except EOFError:
+                    return _abort(
+                        ctx, checkpointer,
+                        "Confirm step received EOF — cannot confirm in "
+                        "non-interactive mode",
+                    )
+                if answer in ("y", "Y"):
+                    break
+                console.print("[dim]Type 'y' or 'Y' to confirm.[/dim]")
+            step.confirmed = True
+            console.print("[green]Confirmed[/green]")
+
+    ctx.current_step = len(ctx.plan)
+    checkpointer.save(ctx)
+    return True
+
+
+def _abort(
+    ctx: LandingContext, checkpointer: AutolandCheckpointer, reason: str
+) -> bool:
+    ctx.abort_reason = reason
+    ctx.aborted = True
+    checkpointer.save(ctx)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def register_parser(
+    subparsers: argparse._SubParsersAction, common_parser: argparse.ArgumentParser
+) -> None:
+    """Register the `autoland` subparser. Called from cli.create_argparser."""
+    p = subparsers.add_parser(
+        "autoland",
+        help="Land the whole stack through the GitHub merge queue",
+        parents=[common_parser],
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover and display the stack, then exit.",
+    )
+    p.add_argument(
+        "--max-check-retries",
+        type=int,
+        default=None,
+        help="Max times to rerun failed CI checks (config: autoland.max_check_retries).",
+    )
+    p.add_argument(
+        "--max-queue-retries",
+        type=int,
+        default=None,
+        help="Max retries after a merge-queue boot (config: autoland.max_queue_retries).",
+    )
+    p.add_argument(
+        "--poll-interval",
+        type=int,
+        default=None,
+        help="Seconds between status polls (config: autoland.poll_interval).",
+    )
+    p.add_argument(
+        "--deploy-timeout",
+        type=int,
+        default=None,
+        help="Seconds to wait for a deploy checkpoint (config: autoland.deploy_timeout).",
+    )
+    p.add_argument(
+        "--branch",
+        default=None,
+        metavar="BRANCH",
+        help="Land a stack rooted on BRANCH using a temporary worktree.",
+    )
+    p.add_argument(
+        "--always-cleanup",
+        action="store_true",
+        help="Always remove the temporary worktree, even on failure.",
+    )
+    p.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Edit the landing plan in $EDITOR (add deploy/confirm checkpoints).",
+    )
+    p.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume a previously interrupted run from its checkpoint.",
+    )
+    p.add_argument(
+        "--state-file",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Override the state file path (default: ~/.stack-pr/autoland/<branch>.json).",
+    )
+
+
+def run_autoland(
+    common: cli.CommonArgs,
+    args: argparse.Namespace,
+    config: configparser.ConfigParser,
+) -> None:
+    """Entry point for `stack-pr autoland`."""
+    opts = AutolandOptions.from_config_and_args(config, args)
+
+    # Merge-queue is the only supported strategy for now. Fail early otherwise.
+    if not opts.merge_queue:
+        raise NotImplementedError(
+            "stack-pr autoland currently supports only repositories that use "
+            "the GitHub merge queue. Enable it with:\n"
+            "    stack-pr config autoland.merge_queue=true"
+        )
+
+    if opts.resume:
+        _run_resume(common, opts)
+        return
+    _run_fresh(common, opts)
+
+
+def _dispose_worktree(
+    worktree: Worktree | None, opts: AutolandOptions, *, succeeded: bool
+) -> None:
+    """Remove the worktree, or preserve it after a failure for debugging."""
+    if worktree is None:
+        return
+    if succeeded or opts.always_cleanup:
+        worktree.remove()
+    else:
+        worktree.announce_preserved()
+
+
+def _install_signal_handler(
+    ctx: LandingContext,
+    checkpointer: AutolandCheckpointer,
+    worktree: Worktree | None,
+    opts: AutolandOptions,
+) -> None:
+    def handler(_sig: int, _frame: object) -> None:
+        ctx.aborted = True
+        ctx.abort_reason = "User interrupted (Ctrl+C)"
+        checkpointer.save(ctx)
+        console.print(
+            "\n[red bold]Interrupted! State saved. Resume with --resume.[/red bold]\n"
+        )
+        print_status(ctx)
+        _dispose_worktree(worktree, opts, succeeded=False)
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT, handler)
+
+
+def _finish(
+    ctx: LandingContext,
+    checkpointer: AutolandCheckpointer,
+    worktree: Worktree | None,
+    opts: AutolandOptions,
+    *,
+    success: bool,
+) -> None:
+    console.print("\n")
+    print_status(ctx)
+    if success:
+        console.print("\n[bold green]All PRs landed successfully![/bold green]\n")
+        checkpointer.delete()
+    else:
+        console.print(f"\n[bold red]Landing failed: {ctx.abort_reason}[/bold red]\n")
+        console.print(
+            f"[dim]State saved to {checkpointer.path} — resume with --resume[/dim]\n"
+        )
+    _dispose_worktree(worktree, opts, succeeded=success)
+    if not success:
+        sys.exit(1)
+
+
+def _run_fresh(common: cli.CommonArgs, opts: AutolandOptions) -> None:
+    worktree: Worktree | None = None
+    if opts.branch:
+        worktree = Worktree(opts.branch)
+        worktree.create()
+        console.print(
+            f"[green]Working in temporary worktree for [bold]{opts.branch}"
+            "[/bold][/green]\n"
+        )
+
+    console.print("\n[bold]Discovering stack...[/bold]\n")
+    stack = discover_stack(common)
+    if not stack:
+        console.print("[red]No stack found on the current branch.[/red]")
+        sys.exit(1)
+    enrich_stack(stack)
+
+    plan = (
+        edit_plan_interactive(stack)
+        if opts.interactive
+        else generate_default_plan(stack)
+    )
+    ctx = LandingContext(stack=stack, plan=plan)
+
+    branch = opts.branch or _current_branch()
+    checkpointer = AutolandCheckpointer(
+        path=opts.state_file or AutolandCheckpointer.default_path(branch),
+        branch=branch,
+        base=common.target,
+    )
+
+    print_status(ctx)
+    if opts.dry_run:
+        console.print("\n[yellow]Dry run — exiting.[/yellow]")
+        return
+
+    console.print(f"[dim]State file: {checkpointer.path}[/dim]\n")
+    _install_signal_handler(ctx, checkpointer, worktree, opts)
+    _finish(
+        ctx, checkpointer, worktree, opts,
+        success=execute_plan(ctx, common, opts, checkpointer),
+    )
+
+
+def _run_resume(common: cli.CommonArgs, opts: AutolandOptions) -> None:
+    if opts.state_file:
+        sf_path = opts.state_file
+    elif opts.branch:
+        sf_path = AutolandCheckpointer.default_path(opts.branch)
+    else:
+        sf_path = AutolandCheckpointer.default_path(_current_branch())
+
+    if not sf_path.exists():
+        console.print(f"[red]No state file found at {sf_path}[/red]")
+        sys.exit(1)
+
+    console.print(f"[bold]Resuming from checkpoint: [cyan]{sf_path}[/cyan][/bold]\n")
+    try:
+        checkpointer, ctx = AutolandCheckpointer.load(sf_path)
+    except (ValueError, json.JSONDecodeError, KeyError) as e:
+        console.print(f"[red]Failed to load state file: {e}[/red]")
+        sys.exit(1)
+
+    if opts.branch and opts.branch != checkpointer.branch:
+        console.print(
+            f"[red]--branch {opts.branch} does not match saved branch "
+            f"{checkpointer.branch}[/red]"
+        )
+        sys.exit(1)
+
+    worktree: Worktree | None = None
+    if opts.branch or checkpointer.branch != _current_branch():
+        worktree = Worktree(opts.branch or checkpointer.branch)
+        worktree.create()
+
+    console.print("[dim]Refreshing PR state from GitHub...[/dim]")
+    enrich_stack(ctx.stack)
+    ctx.aborted = False
+    ctx.abort_reason = ""
+
+    if ctx.current_step >= len(ctx.plan):
+        console.print("[green]All steps already completed — nothing to resume.[/green]")
+        checkpointer.delete()
+        _dispose_worktree(worktree, opts, succeeded=True)
+        return
+
+    print_status(ctx)
+    console.print(f"[dim]State file: {sf_path}[/dim]\n")
+    _install_signal_handler(ctx, checkpointer, worktree, opts)
+    _finish(
+        ctx, checkpointer, worktree, opts,
+        success=execute_plan(ctx, common, opts, checkpointer),
+    )

--- a/src/stack_pr/autoland.py
+++ b/src/stack_pr/autoland.py
@@ -4,7 +4,7 @@
 # subparser and dispatches into `run_autoland` to keep cli.py small.
 #
 # Repo-specific behavior (which CI checks gate a merge, poll intervals,
-# retry counts, deploy timeouts, and whether the repo uses a merge queue at
+# retry counts, workflow timeouts, and whether the repo uses a merge queue at
 # all) is externalized to the `[autoland]` config section and command-line
 # flags, so a repo can reproduce its workflow with configuration alone.
 from __future__ import annotations
@@ -40,7 +40,7 @@ from stack_pr import cli
 DEFAULT_POLL_INTERVAL = 120  # seconds
 DEFAULT_MAX_CHECK_RETRIES = 3
 DEFAULT_MAX_QUEUE_RETRIES = 3
-DEFAULT_DEPLOY_TIMEOUT = 10800  # 3 hours
+DEFAULT_WORKFLOW_TIMEOUT = 10800  # 3 hours
 DEFAULT_MERGE_TIMEOUT = 3600  # 60 minutes
 
 # ---------------------------------------------------------------------------
@@ -90,7 +90,7 @@ class AutolandOptions:
     max_check_retries: int
     max_queue_retries: int
     merge_timeout: int
-    deploy_timeout: int
+    workflow_timeout: int
     dry_run: bool
     branch: str | None
     interactive: bool
@@ -134,10 +134,10 @@ class AutolandOptions:
             merge_timeout=config.getint(
                 "autoland", "merge_timeout", fallback=DEFAULT_MERGE_TIMEOUT
             ),
-            deploy_timeout=_int(
-                getattr(args, "deploy_timeout", None),
-                "deploy_timeout",
-                DEFAULT_DEPLOY_TIMEOUT,
+            workflow_timeout=_int(
+                getattr(args, "workflow_timeout", None),
+                "workflow_timeout",
+                DEFAULT_WORKFLOW_TIMEOUT,
             ),
             dry_run=bool(getattr(args, "dry_run", False)),
             branch=getattr(args, "branch", None),
@@ -158,7 +158,7 @@ class PRState(str, Enum):
     WAITING_FOR_APPROVAL = "waiting_for_approval"
     WAITING_FOR_CHECKS = "waiting_for_checks"
     IN_MERGE_QUEUE = "in_merge_queue"
-    WAITING_FOR_DEPLOY = "waiting_for_deploy"
+    WAITING_FOR_WORKFLOW = "waiting_for_workflow"
     MERGED = "merged"
     FAILED = "failed"
 
@@ -190,8 +190,8 @@ class LandStep:
 
 
 @dataclass
-class DeployStep:
-    """Wait for a deploy workflow to succeed with the landed code."""
+class WorkflowStep:
+    """Wait for a GitHub Actions workflow to succeed with the landed code."""
 
     workflow: str
     state: str = "pending"  # pending, waiting, succeeded, failed
@@ -206,7 +206,7 @@ class ConfirmStep:
     confirmed: bool = False
 
 
-PlanStep = Union[LandStep, DeployStep, ConfirmStep]
+PlanStep = Union[LandStep, WorkflowStep, ConfirmStep]
 
 
 @dataclass
@@ -228,7 +228,7 @@ class LandingContext:
 
 STATE_VERSION = 1
 
-_STEP_TYPES = {LandStep: "land", DeployStep: "deploy", ConfirmStep: "confirm"}
+_STEP_TYPES = {LandStep: "land", WorkflowStep: "workflow", ConfirmStep: "confirm"}
 
 
 def _deserialize_entry(data: dict) -> StackEntry:
@@ -254,8 +254,8 @@ def _deserialize_step(data: dict) -> PlanStep:
     fields = {k: v for k, v in data.items() if k != "type"}
     if data["type"] == "land":
         return LandStep(**fields)
-    if data["type"] == "deploy":
-        return DeployStep(**fields)
+    if data["type"] == "workflow":
+        return WorkflowStep(**fields)
     return ConfirmStep(**fields)
 
 
@@ -785,7 +785,7 @@ def rebase_and_resubmit(common: cli.CommonArgs) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Deploy checkpoint polling
+# Workflow checkpoint polling
 # ---------------------------------------------------------------------------
 
 
@@ -809,18 +809,18 @@ def _is_ancestor(ancestor: str, descendant: str) -> bool:
     return result.returncode == 0
 
 
-def wait_for_deploy(
-    step: DeployStep,
+def wait_for_workflow(
+    step: WorkflowStep,
     *,
     opts: AutolandOptions,
     common: cli.CommonArgs,
     ctx: LandingContext,
 ) -> bool:
-    """Wait for a deploy workflow to complete with code at or after the landed SHA."""
+    """Wait for a workflow to complete with code at or after the landed SHA."""
     target_sha = ctx.last_landed_sha
     step.state = "waiting"
     console.print(
-        f"\n[bold blue]Waiting for deploy: {step.workflow}[/bold blue]"
+        f"\n[bold blue]Waiting for workflow: {step.workflow}[/bold blue]"
         f"\n[dim]Target SHA: {target_sha[:12]}[/dim]"
     )
 
@@ -828,17 +828,17 @@ def wait_for_deploy(
     while True:
         if ctx.aborted:
             return False
-        if awake_elapsed > opts.deploy_timeout:
+        if awake_elapsed > opts.workflow_timeout:
             step.state = "failed"
             step.error_message = (
-                f"Deploy timed out after {opts.deploy_timeout / 3600:.0f}h"
+                f"Workflow timed out after {opts.workflow_timeout / 3600:.0f}h"
             )
             return False
 
         try:
             data = github.workflow_runs(step.workflow, common.target)
         except RuntimeError as e:
-            console.print(f"[yellow]Warning: could not poll deploy: {e}[/yellow]")
+            console.print(f"[yellow]Warning: could not poll workflow: {e}[/yellow]")
             resilient_sleep(opts.poll_interval)
             awake_elapsed += opts.poll_interval
             continue
@@ -855,15 +855,15 @@ def wait_for_deploy(
                 step.state = "succeeded"
                 step.error_message = ""
                 console.print(
-                    f"\n[bold green]Deploy {step.workflow} completed "
+                    f"\n[bold green]Workflow {step.workflow} completed "
                     f"with SHA {run_sha[:12]}[/bold green]"
                 )
                 return True
 
         mins = int(awake_elapsed) // 60
-        step.error_message = f"Waiting for deploy ({mins}m elapsed)..."
+        step.error_message = f"Waiting for workflow ({mins}m elapsed)..."
         console.print(
-            f"[dim]Deploy {step.workflow}: waiting ({mins}m) — "
+            f"[dim]Workflow {step.workflow}: waiting ({mins}m) — "
             f"polling in {opts.poll_interval}s[/dim]"
         )
         resilient_sleep(opts.poll_interval)
@@ -883,7 +883,7 @@ def format_plan_for_editor(stack: list[StackEntry], plan: list[PlanStep]) -> str
     lines = [
         "# Autoland plan — edit steps below.",
         "# l             = land the next PR in the stack",
-        "# d <workflow>  = wait for deploy workflow to complete",
+        "# w <workflow>  = wait for a workflow to complete",
         "# c <message>   = pause and wait for manual confirmation",
         "#",
         "# Lines starting with # are comments and are ignored.",
@@ -894,8 +894,8 @@ def format_plan_for_editor(stack: list[StackEntry], plan: list[PlanStep]) -> str
         if isinstance(step, LandStep):
             entry = stack[step.entry_index]
             lines.append(f"l    # PR #{entry.pr_number}: {entry.title}")
-        elif isinstance(step, DeployStep):
-            lines.append(f"d {step.workflow}")
+        elif isinstance(step, WorkflowStep):
+            lines.append(f"w {step.workflow}")
         elif isinstance(step, ConfirmStep):
             lines.append(f"c {step.message}")
     lines.append("")
@@ -922,13 +922,13 @@ def parse_plan(text: str, stack: list[StackEntry]) -> list[PlanStep]:
                 )
             steps.append(LandStep(entry_index=land_counter))
             land_counter += 1
-        elif line.startswith("d "):
+        elif line.startswith("w "):
             workflow = line[2:].strip()
             if not workflow:
                 raise ValueError(
-                    f"Line {line_num}: 'd' requires a workflow name"
+                    f"Line {line_num}: 'w' requires a workflow name"
                 )
-            steps.append(DeployStep(workflow=workflow))
+            steps.append(WorkflowStep(workflow=workflow))
         elif line == "c" or line.startswith("c "):
             message = (
                 line[2:].strip() if line.startswith("c ") else "Confirm to continue"
@@ -990,7 +990,7 @@ STATE_LABELS = {
     PRState.WAITING_FOR_APPROVAL: "Waiting for approval",
     PRState.WAITING_FOR_CHECKS: "Waiting for checks",
     PRState.IN_MERGE_QUEUE: "In merge queue",
-    PRState.WAITING_FOR_DEPLOY: "Waiting for deploy",
+    PRState.WAITING_FOR_WORKFLOW: "Waiting for workflow",
     PRState.MERGED: "Merged",
     PRState.FAILED: "Failed",
 }
@@ -1000,7 +1000,7 @@ STATE_STYLES = {
     PRState.WAITING_FOR_APPROVAL: "magenta",
     PRState.WAITING_FOR_CHECKS: "yellow",
     PRState.IN_MERGE_QUEUE: "cyan",
-    PRState.WAITING_FOR_DEPLOY: "blue",
+    PRState.WAITING_FOR_WORKFLOW: "blue",
     PRState.MERGED: "green",
     PRState.FAILED: "red bold",
 }
@@ -1011,10 +1011,10 @@ _REVIEW_DECISION_DISPLAY = {
     "CHANGES_REQUESTED": ("Changes requested", "red"),
 }
 
-_DEPLOY_STEP_STYLES = {
+_WORKFLOW_STEP_STYLES = {
     "pending": ("Pending", "dim"),
-    "waiting": ("Waiting for deploy", "blue"),
-    "succeeded": ("Deploy complete", "green"),
+    "waiting": ("Waiting for workflow", "blue"),
+    "succeeded": ("Workflow complete", "green"),
     "failed": ("Failed", "red bold"),
 }
 
@@ -1049,13 +1049,13 @@ def render_status_table(ctx: LandingContext) -> Table:  # pragma: no cover
                 "  Retries",
                 f"CI {entry.check_retries} - MQ {entry.queue_retries}",
             )
-        elif isinstance(step, DeployStep):
+        elif isinstance(step, WorkflowStep):
             table.add_row(
                 f"{pointer} Step {step_idx + 1}/{len(plan)}",
-                Text("Deploy checkpoint", style="bold blue"),
+                Text("Workflow checkpoint", style="bold blue"),
             )
             table.add_row("  Workflow", step.workflow)
-            label, ds_style = _DEPLOY_STEP_STYLES.get(step.state, ("Pending", "dim"))
+            label, ds_style = _WORKFLOW_STEP_STYLES.get(step.state, ("Pending", "dim"))
             table.add_row("  Status", Text(label, style=ds_style))
         elif isinstance(step, ConfirmStep):
             table.add_row(
@@ -1087,10 +1087,10 @@ def render_status_plain(ctx: LandingContext) -> str:
             lines.append(
                 f"      retries: CI {e.check_retries} / MQ {e.queue_retries}"
             )
-        elif isinstance(step, DeployStep):
-            label, _ = _DEPLOY_STEP_STYLES.get(step.state, ("Pending", ""))
+        elif isinstance(step, WorkflowStep):
+            label, _ = _WORKFLOW_STEP_STYLES.get(step.state, ("Pending", ""))
             lines.append(
-                f"{cur} [{i + 1}/{len(plan)}] Deploy: {step.workflow} — {label}"
+                f"{cur} [{i + 1}/{len(plan)}] Workflow: {step.workflow} — {label}"
             )
         elif isinstance(step, ConfirmStep):
             state = (
@@ -1459,17 +1459,17 @@ def execute_plan(
                         f"Rebase failed after merging #{entry.pr_number}: {e}",
                     )
 
-        elif isinstance(step, DeployStep):
+        elif isinstance(step, WorkflowStep):
             console.print(
                 f"\n{'=' * 60}\n[bold]Step {step_idx + 1}/{len(ctx.plan)}: "
-                f"Deploy checkpoint — {step.workflow}[/bold]\n{'=' * 60}"
+                f"Workflow checkpoint — {step.workflow}[/bold]\n{'=' * 60}"
             )
             if not ctx.last_landed_sha:
                 _refresh_last_landed_sha(ctx, common)
-            if not wait_for_deploy(step, opts=opts, common=common, ctx=ctx):
+            if not wait_for_workflow(step, opts=opts, common=common, ctx=ctx):
                 return _abort(
                     ctx, checkpointer,
-                    f"Deploy {step.workflow} failed or timed out",
+                    f"Workflow {step.workflow} failed or timed out",
                 )
 
         elif isinstance(step, ConfirmStep):
@@ -1550,10 +1550,13 @@ def register_parser(
         help="Seconds between status polls (config: autoland.poll_interval).",
     )
     p.add_argument(
-        "--deploy-timeout",
+        "--workflow-timeout",
         type=int,
         default=None,
-        help="Seconds to wait for a deploy checkpoint (config: autoland.deploy_timeout).",
+        help=(
+            "Seconds to wait for a workflow checkpoint "
+            "(config: autoland.workflow_timeout)."
+        ),
     )
     p.add_argument(
         "--branch",
@@ -1570,7 +1573,7 @@ def register_parser(
         "-i",
         "--interactive",
         action="store_true",
-        help="Edit the landing plan in $EDITOR (add deploy/confirm checkpoints).",
+        help="Edit the landing plan in $EDITOR (add workflow/confirm checkpoints).",
     )
     p.add_argument(
         "--resume",

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -1936,6 +1936,11 @@ def create_argparser(
         parents=[common_parser],
     )
 
+    # autoland lives in its own module to keep this file small.
+    from stack_pr import autoland  # noqa: PLC0415
+
+    autoland.register_parser(subparsers, common_parser)
+
     parser_config = subparsers.add_parser(
         "config",
         help="Set a configuration value",
@@ -1955,7 +1960,7 @@ def load_config(config_file: str | Path) -> configparser.ConfigParser:
     return config
 
 
-def main() -> None:  # noqa: PLR0912
+def main() -> None:  # noqa: PLR0912, PLR0915
     repo_config_file = get_repo_root() / ".stack-pr.cfg"
     config_file = os.getenv("STACKPR_CONFIG", repo_config_file)
     config = load_config(config_file)
@@ -2004,7 +2009,9 @@ def main() -> None:  # noqa: PLR0912
             output = result.stdout.decode() if result.stdout else ""
             stashed_changes = "No local changes to save" not in output
 
-        if args.command != "view" and not is_repo_clean():
+        # autoland may operate in a temporary worktree (--branch), so the
+        # primary checkout being dirty shouldn't block it.
+        if args.command not in ("view", "autoland") and not is_repo_clean():
             error(ERROR_REPO_DIRTY)
             return
         check_target_branch_exists(common_args)
@@ -2030,6 +2037,10 @@ def main() -> None:  # noqa: PLR0912
             )
         elif args.command == "view":
             command_view(common_args)
+        elif args.command == "autoland":
+            from stack_pr import autoland  # noqa: PLC0415
+
+            autoland.run_autoland(common_args, args, config)
         else:
             print(h(red("Unknown command: " + args.command)))
             return

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -1803,6 +1803,40 @@ def command_config(config_file: str, setting: str) -> None:
     print(f"Set {section}.{key} = {value}")
 
 
+def command_install(name: str, *, local: bool) -> None:
+    """Install stack-pr as a git alias so it can be run as `git <name>`.
+
+    Writes e.g. ``[alias] stack = !stack-pr`` to the user's git config.
+    """
+    scope = "--local" if local else "--global"
+    alias_value = "!stack-pr"
+    run_shell_command(
+        ["git", "config", scope, f"alias.{name}", alias_value],
+        quiet=True,
+    )
+    print(f"Installed git alias '{name}' -> '{alias_value}' ({scope}).")
+    print("\nYou can now invoke stack-pr through git, e.g.:")
+    print(f"  git {name} view")
+    print(f"  git {name} submit")
+    print(
+        f"  git {name} help     # note: 'git {name} --help' is intercepted by git,"
+    )
+    print(f"                      # so use 'git {name} help' instead.")
+
+
+def command_help(parser: argparse.ArgumentParser, topic: str | None) -> None:
+    """Print help. With a *topic*, show that subcommand's help.
+
+    Exists so `git stack help [cmd]` works: git intercepts `git stack --help`
+    for aliases and only prints "'stack' is aliased to '!stack-pr'".
+    """
+    if topic:
+        # Defer to argparse's own per-subcommand help (this exits the process).
+        parser.parse_args([topic, "--help"])
+    else:
+        parser.print_help()
+
+
 # ===----------------------------------------------------------------------=== #
 # Main entry point
 # ===----------------------------------------------------------------------=== #
@@ -1950,6 +1984,32 @@ def create_argparser(
         help="Configuration setting in format <section>.<key>=<value>",
     )
 
+    parser_install = subparsers.add_parser(
+        "install",
+        help="Install stack-pr as a git alias (e.g. so `git stack` works)",
+    )
+    parser_install.add_argument(
+        "--name",
+        default="stack",
+        help="Git alias name to create (default: stack, i.e. `git stack ...`).",
+    )
+    parser_install.add_argument(
+        "--local",
+        action="store_true",
+        help="Write to the repository's git config instead of the global one.",
+    )
+
+    parser_help = subparsers.add_parser(
+        "help",
+        help="Show help (use `git stack help`; `git stack --help` is intercepted by git)",
+    )
+    parser_help.add_argument(
+        "topic",
+        nargs="?",
+        default=None,
+        help="Optional subcommand to show help for (e.g. `help submit`).",
+    )
+
     return parser
 
 
@@ -1960,7 +2020,7 @@ def load_config(config_file: str | Path) -> configparser.ConfigParser:
     return config
 
 
-def main() -> None:  # noqa: PLR0912, PLR0915
+def main() -> None:  # noqa: PLR0912, PLR0915, C901
     repo_config_file = get_repo_root() / ".stack-pr.cfg"
     config_file = os.getenv("STACKPR_CONFIG", repo_config_file)
     config = load_config(config_file)
@@ -1980,6 +2040,14 @@ def main() -> None:  # noqa: PLR0912, PLR0915
     # Handle config command early since it doesn't need git repo setup
     if args.command == "config":
         command_config(config_file, args.setting)
+        return
+
+    # These commands don't need gh/target/stack setup either.
+    if args.command == "help":
+        command_help(parser, args.topic)
+        return
+    if args.command == "install":
+        command_install(args.name, local=args.local)
         return
 
     # Make sure "$ID" is present in the branch name template and append it if not

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -61,7 +61,7 @@ from functools import cache
 from logging import getLogger
 from pathlib import Path
 from re import Pattern
-from subprocess import SubprocessError
+from subprocess import PIPE, SubprocessError
 
 from stack_pr.git import (
     branch_exists,
@@ -450,6 +450,10 @@ def red(s: str) -> str:
     return ShellColors.FAIL + s + ShellColors.ENDC
 
 
+def yellow(s: str) -> str:
+    return ShellColors.WARNING + s + ShellColors.ENDC
+
+
 # https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 def link(location: str, text: str) -> str:
     """
@@ -462,6 +466,10 @@ def link(location: str, text: str) -> str:
 
 def error(msg: str) -> None:
     print(red("\nERROR: ") + msg)
+
+
+def warning(msg: str) -> None:
+    print(yellow("\nWARNING: ") + msg)
 
 
 def log(msg: str, *, level: int = 1) -> None:
@@ -887,6 +895,49 @@ def get_pr_body(e: StackEntry) -> str:
     return str(json.loads(out)["body"] or "").strip()
 
 
+def edit_pr_base(
+    pr: str,
+    base: str,
+    *,
+    extra_args: list[str] | None = None,
+    verbose: bool,
+    **kwargs: object,
+) -> None:
+    """Run ``gh pr edit <pr> -B <base> [extra_args]``, tolerating merge queues.
+
+    GitHub refuses to change the base branch of a PR that has been added to a
+    merge queue (``Cannot change the base branch because the branch has been
+    added to a merge queue``). Such a PR is already on its way to landing, so
+    instead of crashing we warn and retry the edit without the ``-B`` flag, so
+    any other updates (``extra_args``, e.g. title/body) still get applied.
+    """
+    extra_args = extra_args or []
+    result = run_shell_command(
+        ["gh", "pr", "edit", pr, "-B", base, *extra_args],
+        quiet=not verbose,
+        check=False,
+        stderr=PIPE,
+        **kwargs,
+    )
+    if result.returncode == 0:
+        return
+
+    stderr = (result.stderr or b"").decode("utf-8", errors="replace")
+    if "merge queue" not in stderr:
+        sys.stderr.write(stderr)
+        raise SubprocessError(f"Failed to edit {pr} (exit code {result.returncode}).")
+
+    warning(
+        f"Could not change the base branch of {pr}: it has been added to a "
+        "merge queue. Leaving its base branch unchanged."
+    )
+    if extra_args:
+        # Re-run without the base change so the remaining edits still apply.
+        run_shell_command(
+            ["gh", "pr", "edit", pr, *extra_args], quiet=not verbose, **kwargs
+        )
+
+
 def add_cross_links(st: list[StackEntry], *, keep_body: bool, verbose: bool) -> None:
     # Build the maintained list of PRs once - it's identical for every PR in
     # the stack (apart from which one is marked as current).
@@ -922,10 +973,12 @@ def add_cross_links(st: list[StackEntry], *, keep_body: bool, verbose: bool) -> 
         pr_body = [*header, body_content]
 
         if e.has_base():
-            run_shell_command(
-                ["gh", "pr", "edit", e.pr, "-t", title, "-F", "-", "-B", e.base or ""],
+            edit_pr_base(
+                e.pr,
+                e.base or "",
+                extra_args=["-t", title, "-F", "-"],
+                verbose=verbose,
                 input="\n".join(pr_body).encode(),
-                quiet=not verbose,
             )
         else:
             error("Stack entry has no base branch")
@@ -975,7 +1028,7 @@ def reset_remote_base_branches(
         if not is_draft_pr(e):
             run_shell_command(["gh", "pr", "ready", e.pr, "--undo"], quiet=not verbose)
             e.is_tmp_draft = True
-        run_shell_command(["gh", "pr", "edit", e.pr, "-B", target], quiet=not verbose)
+        edit_pr_base(e.pr, target, verbose=verbose)
 
 
 # If local 'main' lags behind 'origin/main', and 'head' contains all commits

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -110,6 +110,11 @@ RE_STACK_INFO_LINE = re.compile(
 RE_PR_TOC = re.compile(
     r"^Stacked PRs:\r?\n(^ \* (__->__)?#\d+\r?\n)*\r?\n", re.MULTILINE
 )
+# A single entry in the cross-links table of contents, e.g. " * __->__#42".
+RE_TOC_ENTRY = re.compile(r"^ \* (?:__->__)?#(\d+)\s*$", re.MULTILINE)
+
+# Header line introducing the cross-links table of contents.
+STACK_TOC_HEADER = "Stacked PRs:"
 
 # Delimeter for PR body
 CROSS_LINKS_DELIMETER = "--- --- ---"
@@ -810,18 +815,69 @@ def create_pr(e: StackEntry, *, is_draft: bool, reviewer: str = "") -> None:
     e.pr = r.split()[-1]
 
 
-def generate_toc(st: list[StackEntry], current: str) -> str:
-    # Don't generate TOC for single PR
-    if len(st) == 1:
+def extract_toc_pr_ids(body: str) -> list[str]:
+    """Extract the PR ids recorded in a PR body's cross-links table.
+
+    Returns the ids in bottom-to-top stack order (the table is rendered
+    top-first, so the result is reversed). Returns an empty list if the body
+    doesn't contain a recognizable cross-links table.
+    """
+    if CROSS_LINKS_DELIMETER not in body:
+        return []
+    header = body.split(CROSS_LINKS_DELIMETER, 1)[0]
+    if STACK_TOC_HEADER not in header:
+        return []
+    # findall yields ids top-first (as rendered); reverse to bottom-first.
+    return RE_TOC_ENTRY.findall(header)[::-1]
+
+
+def get_pr_state(pr_id: str) -> str:
+    """Return the GitHub state of a PR: 'OPEN', 'MERGED', or 'CLOSED'."""
+    out = get_command_output(["gh", "pr", "view", pr_id, "--json", "state"])
+    return str(json.loads(out)["state"])
+
+
+def build_stack_pr_list(st: list[StackEntry]) -> list[str]:
+    """Build the ordered list of PR ids to show in every PR's cross-links.
+
+    The list is maintained across submits: PRs that have left the active stack
+    but were previously part of it (i.e. they merged or were closed) are kept,
+    pinned below the active stack in their original order. PRs that left the
+    stack but are still open are dropped. The result is bottom-to-top order.
+    """
+    active_ids = [last(e.pr) for e in st]
+    active_set = set(active_ids)
+
+    # Recover the previously recorded list from a surviving PR's body. Every PR
+    # carries the full list, so the first one with a recognizable table wins.
+    historical: list[str] = []
+    for e in st:
+        historical = extract_toc_pr_ids(get_pr_body(e))
+        if historical:
+            break
+
+    # Keep historical entries that have left the stack but aren't open anymore.
+    inactive: list[str] = []
+    for pr_id in historical:
+        if pr_id in active_set or pr_id in inactive:
+            continue
+        if get_pr_state(pr_id) != "OPEN":
+            inactive.append(pr_id)
+
+    return inactive + active_ids
+
+
+def generate_toc(pr_ids: list[str], current: str) -> str:
+    # Don't generate a table of contents for a lone PR with no history.
+    if len(pr_ids) <= 1:
         return ""
 
-    def toc_entry(se: StackEntry) -> str:
-        pr_id = last(se.pr)
+    def toc_entry(pr_id: str) -> str:
         arrow = "__->__" if pr_id == current else ""
         return f" * {arrow}#{pr_id}\n"
 
-    entries = (toc_entry(se) for se in st[::-1])
-    return f"Stacked PRs:\n{''.join(entries)}\n"
+    entries = (toc_entry(pr_id) for pr_id in pr_ids[::-1])
+    return f"{STACK_TOC_HEADER}\n{''.join(entries)}\n"
 
 
 def get_pr_body(e: StackEntry) -> str:
@@ -832,9 +888,13 @@ def get_pr_body(e: StackEntry) -> str:
 
 
 def add_cross_links(st: list[StackEntry], *, keep_body: bool, verbose: bool) -> None:
+    # Build the maintained list of PRs once - it's identical for every PR in
+    # the stack (apart from which one is marked as current).
+    pr_ids = build_stack_pr_list(st)
+
     for e in st:
         pr_id = last(e.pr)
-        pr_toc = generate_toc(st, pr_id)
+        pr_toc = generate_toc(pr_ids, pr_id)
 
         title = e.commit.title()
         body = e.commit.commit_msg()

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -231,6 +231,42 @@ If you'd like to land stack except the top N commits, you could use the followin
 If you prefer to merge via the github web UI, please don't forget to edit commit message on the merge page!
 If you use the default commit message filled by the web UI, links to other PRs from the stack will be included in the commit message.
 """
+ADOPT_TIP = """
+The bottom commit is now linked to the adopted PR. To verify and apply:
+  $ stack-pr view     # confirm the stack looks right
+  $ stack-pr submit   # update the adopted PR and push the rest of the stack
+"""
+ERROR_ADOPT_ALREADY_MANAGED = """The bottom commit is already managed by stack-pr:
+    {e}
+
+There is nothing to adopt. Use 'submit' to update the stack.
+"""
+ERROR_ADOPT_NO_PR = """Could not find a PR to adopt.
+
+Run 'stack-pr adopt' while checked out on the branch whose PR you want to
+adopt, or pass the PR explicitly:
+  $ stack-pr adopt <pr-number-or-url>
+
+Failed trying to execute {cmd}
+"""
+ERROR_ADOPT_PR_NOT_OPEN = """Cannot adopt PR {pr}: it is in '{state}' state, not 'OPEN'.
+
+Only open PRs can be brought under stack-pr management.
+"""
+ERROR_ADOPT_BAD_COMMIT = """Could not resolve commit '{commit}'.
+
+Failed trying to execute {cmd}
+"""
+ERROR_ADOPT_COMMIT_NOT_IN_STACK = """Commit '{commit}' ({sha}) is not part of the current stack.
+
+The commit to adopt must be one of the commits in the range being inspected
+(use 'stack-pr view' to see them, and -B/-H to adjust the range).
+"""
+WARN_ADOPT_CONTENT_DIFFERS = """
+Warning: the local bottom commit's contents differ from the head of PR {pr}.
+The next 'stack-pr submit' will force-push the local commit and update the PR's
+diff accordingly. Double-check the commit content before submitting.
+"""
 
 
 # ===----------------------------------------------------------------------=== #
@@ -575,6 +611,11 @@ def draft_bitmask_type(value: str) -> list[bool]:
 # ===----------------------------------------------------------------------=== #
 # SUBMIT
 # ===----------------------------------------------------------------------=== #
+def format_stack_info(pr: str, branch: str) -> str:
+    """Format the stack-info metadata trailer for a commit message."""
+    return f"stack-info: PR: {pr}, branch: {branch}"
+
+
 def add_or_update_metadata(e: StackEntry, *, needs_rebase: bool, verbose: bool) -> bool:
     if needs_rebase:
         if not e.has_base() or not e.has_head():
@@ -605,7 +646,7 @@ def add_or_update_metadata(e: StackEntry, *, needs_rebase: bool, verbose: bool) 
         return needs_rebase
 
     # Add the stack info metadata to the commit message
-    commit_msg += f"\n\nstack-info: PR: {e.pr}, branch: {e.head}"
+    commit_msg += "\n\n" + format_stack_info(e.pr, e.head)
     run_shell_command(
         ["git", "commit", "--amend", "-F", "-"],
         input=commit_msg.encode(),
@@ -1419,6 +1460,184 @@ def command_abandon(args: CommonArgs) -> None:
 
 
 # ===----------------------------------------------------------------------=== #
+# ADOPT
+# ===----------------------------------------------------------------------=== #
+def get_adopt_pr_info(pr: str | None) -> dict:
+    """Look up the PR to adopt via 'gh'.
+
+    With no explicit `pr`, this resolves the PR associated with the currently
+    checked-out branch. Returns the parsed JSON object from 'gh pr view'.
+    """
+    cmd = ["gh", "pr", "view"]
+    if pr:
+        cmd.append(pr)
+    cmd += ["--json", "number,headRefName,headRefOid,state,url"]
+    try:
+        out = get_command_output(cmd)
+    except SubprocessError:
+        error(ERROR_ADOPT_NO_PR.format(cmd=cmd))
+        raise
+    return json.loads(out)
+
+
+def warn_if_content_differs(
+    e: StackEntry, pr_info: dict, *, remote: str, verbose: bool
+) -> None:
+    """Warn if the local commit's tree differs from the adopted PR's head.
+
+    'submit' will force-push the local commit to the PR's branch, so a mismatch
+    means the PR's diff will change. This is informational only; it never blocks
+    adoption, and silently does nothing if the comparison can't be made.
+    """
+    head_oid = pr_info.get("headRefOid")
+    if not head_oid:
+        return
+
+    object_present = (
+        run_shell_command(
+            ["git", "cat-file", "-e", head_oid], quiet=True, check=False
+        ).returncode
+        == 0
+    )
+    if not object_present:
+        run_shell_command(
+            ["git", "fetch", remote, pr_info["headRefName"]],
+            quiet=not verbose,
+            check=False,
+        )
+
+    try:
+        pr_tree = get_command_output(["git", "rev-parse", f"{head_oid}^{{tree}}"])
+    except SubprocessError:
+        # Couldn't resolve the PR head locally; skip the comparison.
+        return
+
+    if pr_tree != e.commit.tree():
+        log(red(WARN_ADOPT_CONTENT_DIFFERS.format(pr=pr_info["url"])))
+
+
+def adopt_commit(
+    e: StackEntry, pr: str, branch: str, *, current_branch: str, verbose: bool
+) -> None:
+    """Embed stack-info metadata into a selected commit of the stack.
+
+    The target commit may not be HEAD (commits can be stacked on top of it), so
+    the message is rewritten on a detached checkout and the rest of the branch
+    is replayed onto the rewritten commit.
+    """
+    old_sha = e.commit.commit_id()
+    new_msg = e.commit.commit_msg() + "\n\n" + format_stack_info(pr, branch)
+
+    run_shell_command(["git", "checkout", old_sha], quiet=not verbose)
+    run_shell_command(
+        ["git", "commit", "--amend", "-F", "-"],
+        input=new_msg.encode(),
+        quiet=not verbose,
+    )
+    new_sha = get_command_output(["git", "rev-parse", "HEAD"])
+
+    # Replay any commits stacked on top of the target onto the rewritten commit.
+    run_shell_command(
+        [
+            "git",
+            "rebase",
+            "--onto",
+            new_sha,
+            old_sha,
+            current_branch,
+            "--committer-date-is-author-date",
+        ],
+        quiet=not verbose,
+    )
+
+
+def print_tips_after_adopt(st: list[StackEntry], args: CommonArgs) -> None:
+    if not st or not args.show_tips:
+        return
+    log(ADOPT_TIP)
+
+
+def select_adopt_entry(st: list[StackEntry], commit: str | None) -> StackEntry:
+    """Pick the stack entry to adopt the PR onto.
+
+    Defaults to the bottom-most commit; if `commit` is given, resolves it and
+    matches it against the entries in the stack.
+    """
+    if commit is None:
+        # The bottom-most commit is the entry whose base is the target branch.
+        return st[0]
+
+    try:
+        sha = get_command_output(["git", "rev-parse", commit])
+    except SubprocessError:
+        error(ERROR_ADOPT_BAD_COMMIT.format(commit=commit, cmd=["git", "rev-parse", commit]))
+        raise
+
+    for e in st:
+        if e.commit.commit_id() == sha:
+            return e
+
+    error(ERROR_ADOPT_COMMIT_NOT_IN_STACK.format(commit=commit, sha=sha))
+    sys.exit(1)
+
+
+# ===----------------------------------------------------------------------=== #
+# Entry point for 'adopt' command
+# ===----------------------------------------------------------------------=== #
+def command_adopt(args: CommonArgs, pr: str | None, commit: str | None) -> None:
+    log(h("ADOPT"))
+
+    st = get_stack(base=args.base, head=args.head, verbose=args.verbose)
+    if not st:
+        log(h("Empty stack!"))
+        log(h(blue("SUCCESS!")))
+        return
+
+    # By default adopt applies to the bottom-most commit (the entry whose base
+    # is the target branch); a specific commit can be targeted with --commit.
+    e = select_adopt_entry(st, commit)
+    if RE_STACK_INFO_LINE.search(e.commit.commit_msg()):
+        error(ERROR_ADOPT_ALREADY_MANAGED.format(e=e))
+        sys.exit(1)
+
+    pr_info = get_adopt_pr_info(pr)
+    state = pr_info.get("state")
+    if state != "OPEN":
+        error(ERROR_ADOPT_PR_NOT_OPEN.format(pr=pr_info.get("url", pr), state=state))
+        sys.exit(1)
+
+    pr_url = pr_info["url"]
+    head_ref = pr_info["headRefName"]
+
+    warn_if_content_differs(e, pr_info, remote=args.remote, verbose=args.verbose)
+
+    current_branch = get_current_branch_name()
+    log(
+        h(
+            f"Adopting PR {pr_url} (branch '{head_ref}') onto "
+            + e.pprint(links=False)
+        )
+    )
+    adopt_commit(
+        e, pr_url, head_ref, current_branch=current_branch, verbose=args.verbose
+    )
+
+    # Re-read the stack to reflect the freshly embedded metadata and show it.
+    run_shell_command(["git", "checkout", current_branch], quiet=not args.verbose)
+    st = get_stack(base=args.base, head=args.head, verbose=args.verbose)
+    set_head_branches(
+        st,
+        remote=args.remote,
+        verbose=args.verbose,
+        branch_name_template=args.branch_name_template,
+    )
+    set_base_branches(st, target=args.target)
+    print_stack(st, links=args.hyperlinks)
+    print_tips_after_adopt(st, args)
+    log(h(blue("SUCCESS!")))
+
+
+# ===----------------------------------------------------------------------=== #
 # VIEW
 # ===----------------------------------------------------------------------=== #
 def print_tips_after_view(st: list[StackEntry], args: CommonArgs) -> None:
@@ -1629,6 +1848,28 @@ def create_argparser(
         help="Abandon the current stack",
         parents=[common_parser],
     )
+    parser_adopt = subparsers.add_parser(
+        "adopt",
+        help="Bring an existing PR under stack-pr management",
+        parents=[common_parser],
+    )
+    parser_adopt.add_argument(
+        "pr",
+        nargs="?",
+        default=None,
+        help=(
+            "PR number or URL to adopt. If omitted, the PR of the current "
+            "branch is used."
+        ),
+    )
+    parser_adopt.add_argument(
+        "--commit",
+        default=None,
+        help=(
+            "Commit to attach the PR to (any git revision). If omitted, the "
+            "bottom-most commit of the stack is used."
+        ),
+    )
     subparsers.add_parser(
         "view",
         help="Inspect the current stack",
@@ -1721,6 +1962,12 @@ def main() -> None:  # noqa: PLR0912
             command_land(common_args)
         elif args.command == "abandon":
             command_abandon(common_args)
+        elif args.command == "adopt":
+            command_adopt(
+                common_args,
+                getattr(args, "pr", None),
+                getattr(args, "commit", None),
+            )
         elif args.command == "view":
             command_view(common_args)
         else:

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -1,0 +1,161 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+import pytest
+
+from stack_pr import cli
+from stack_pr.cli import (
+    RE_STACK_INFO_LINE,
+    format_stack_info,
+    get_adopt_pr_info,
+    select_adopt_entry,
+)
+
+
+def test_format_stack_info() -> None:
+    assert (
+        format_stack_info("https://github.com/o/r/pull/3", "feat")
+        == "stack-info: PR: https://github.com/o/r/pull/3, branch: feat"
+    )
+
+
+def test_format_stack_info_roundtrips_with_regex() -> None:
+    """A formatted trailer must be parseable by the metadata regex."""
+    pr = "https://github.com/o/r/pull/42"
+    branch = "user/feature"
+    msg = "Some title\n\nSome body\n\n" + format_stack_info(pr, branch)
+
+    m = RE_STACK_INFO_LINE.search(msg)
+    assert m is not None
+    assert m.group(1) == pr
+    assert m.group(2) == branch
+
+
+def test_get_adopt_pr_info_no_arg_uses_current_branch(mocker) -> None:  # noqa: ANN001
+    out = '{"number": 7, "headRefName": "feat", "state": "OPEN", "url": "u"}'
+    spy = mocker.patch("stack_pr.cli.get_command_output", return_value=out)
+
+    info = get_adopt_pr_info(None)
+
+    assert info["number"] == 7
+    cmd = spy.call_args.args[0]
+    # No PR specified -> 'gh pr view' resolves the current branch's PR.
+    assert cmd[:3] == ["gh", "pr", "view"]
+    assert "--json" in cmd
+
+
+def test_get_adopt_pr_info_with_arg(mocker) -> None:  # noqa: ANN001
+    out = '{"number": 9, "headRefName": "feat", "state": "OPEN", "url": "u"}'
+    spy = mocker.patch("stack_pr.cli.get_command_output", return_value=out)
+
+    get_adopt_pr_info("9")
+
+    cmd = spy.call_args.args[0]
+    assert "9" in cmd
+
+
+def _fake_entry(mocker, *, commit_msg: str, commit_id: str = "abc123"):  # noqa: ANN001, ANN202
+    commit = mocker.Mock()
+    commit.commit_msg.return_value = commit_msg
+    commit.commit_id.return_value = commit_id
+    commit.tree.return_value = "tree-sha"
+    entry = mocker.Mock()
+    entry.commit = commit
+    entry.pprint.return_value = "entry"
+    return entry
+
+
+def _fake_stack(mocker, *, commit_msg: str):  # noqa: ANN001, ANN202
+    return [_fake_entry(mocker, commit_msg=commit_msg)]
+
+
+def _common_args() -> cli.CommonArgs:
+    return cli.CommonArgs(
+        base="main",
+        head="HEAD",
+        remote="origin",
+        target="main",
+        hyperlinks=False,
+        verbose=False,
+        branch_name_template="$USERNAME/stack/$ID",
+        show_tips=False,
+        land_disabled=False,
+    )
+
+
+def test_select_adopt_entry_defaults_to_bottom(mocker) -> None:  # noqa: ANN001
+    st = [
+        _fake_entry(mocker, commit_msg="bottom", commit_id="aaa"),
+        _fake_entry(mocker, commit_msg="top", commit_id="bbb"),
+    ]
+    assert select_adopt_entry(st, None) is st[0]
+
+
+def test_select_adopt_entry_matches_commit(mocker) -> None:  # noqa: ANN001
+    st = [
+        _fake_entry(mocker, commit_msg="bottom", commit_id="aaa"),
+        _fake_entry(mocker, commit_msg="top", commit_id="bbb"),
+    ]
+    mocker.patch("stack_pr.cli.get_command_output", return_value="bbb")
+    assert select_adopt_entry(st, "HEAD") is st[1]
+
+
+def test_select_adopt_entry_commit_not_in_stack(mocker) -> None:  # noqa: ANN001
+    st = [_fake_entry(mocker, commit_msg="bottom", commit_id="aaa")]
+    mocker.patch("stack_pr.cli.get_command_output", return_value="zzz")
+    with pytest.raises(SystemExit):
+        select_adopt_entry(st, "deadbeef")
+
+
+def test_command_adopt_refuses_already_managed(mocker) -> None:  # noqa: ANN001
+    msg = "Title\n\nstack-info: PR: https://x/pull/1, branch: feat\n"
+    mocker.patch("stack_pr.cli.get_stack", return_value=_fake_stack(mocker, commit_msg=msg))
+
+    with pytest.raises(SystemExit):
+        cli.command_adopt(_common_args(), None, None)
+
+
+def test_command_adopt_refuses_non_open_pr(mocker) -> None:  # noqa: ANN001
+    mocker.patch(
+        "stack_pr.cli.get_stack",
+        return_value=_fake_stack(mocker, commit_msg="Plain title\n\nbody"),
+    )
+    mocker.patch(
+        "stack_pr.cli.get_adopt_pr_info",
+        return_value={"state": "MERGED", "url": "u", "headRefName": "feat"},
+    )
+
+    with pytest.raises(SystemExit):
+        cli.command_adopt(_common_args(), "5", None)
+
+
+def test_command_adopt_embeds_metadata(mocker) -> None:  # noqa: ANN001
+    stack = _fake_stack(mocker, commit_msg="Plain title\n\nbody")
+    # First call returns the unmanaged stack; second call (after adoption) is
+    # only used to print, so the same stack is fine.
+    mocker.patch("stack_pr.cli.get_stack", return_value=stack)
+    mocker.patch(
+        "stack_pr.cli.get_adopt_pr_info",
+        return_value={
+            "state": "OPEN",
+            "url": "https://github.com/o/r/pull/5",
+            "headRefName": "feat",
+            "headRefOid": "deadbeef",
+        },
+    )
+    mocker.patch("stack_pr.cli.get_current_branch_name", return_value="feat")
+    mocker.patch("stack_pr.cli.warn_if_content_differs")
+    mocker.patch("stack_pr.cli.set_head_branches")
+    mocker.patch("stack_pr.cli.set_base_branches")
+    mocker.patch("stack_pr.cli.print_stack")
+    adopt_spy = mocker.patch("stack_pr.cli.adopt_commit")
+    mocker.patch("stack_pr.cli.run_shell_command")
+
+    cli.command_adopt(_common_args(), "5", None)
+
+    adopt_spy.assert_called_once()
+    args = adopt_spy.call_args.args
+    assert args[1] == "https://github.com/o/r/pull/5"  # pr url
+    assert args[2] == "feat"  # branch == PR head ref

--- a/tests/test_autoland.py
+++ b/tests/test_autoland.py
@@ -175,6 +175,106 @@ def test_poll_merge_still_queued(mocker) -> None:  # noqa: ANN001
     assert not res.error
 
 
+# --- workflow checkpoint SHA ---------------------------------------------
+
+
+def _opts(**overrides) -> AutolandOptions:  # noqa: ANN003
+    base = {
+        "merge_queue": True,
+        "required_checks": [],
+        "poll_interval": 0,
+        "max_check_retries": 0,
+        "max_queue_retries": 0,
+        "merge_timeout": 0,
+        "workflow_timeout": 3600,
+        "default_workflow": None,
+        "dry_run": False,
+        "branch": None,
+        "interactive": False,
+        "resume": False,
+        "state_file": None,
+        "always_cleanup": False,
+    }
+    base.update(overrides)
+    return AutolandOptions(**base)
+
+
+def test_merge_commit_parses_oid(mocker) -> None:  # noqa: ANN001
+    mocker.patch.object(
+        autoland, "gh_json", return_value={"mergeCommit": {"oid": "deadbeef"}}
+    )
+    assert autoland.github.merge_commit(1) == "deadbeef"
+
+
+def test_merge_commit_none_when_unmerged(mocker) -> None:  # noqa: ANN001
+    mocker.patch.object(autoland, "gh_json", return_value={"mergeCommit": None})
+    assert autoland.github.merge_commit(1) is None
+
+
+def test_refresh_last_landed_sha_prefers_merge_commit(mocker) -> None:  # noqa: ANN001
+    # origin/<target> HEAD has advanced past our merge commit (bot commits,
+    # other PRs). We must record OUR merge commit, not the moving HEAD.
+    mocker.patch.object(autoland, "run")  # git fetch is a no-op
+    mocker.patch.object(autoland.github, "merge_commit", return_value="mergesha")
+    ctx = LandingContext(last_landed_sha="")
+    autoland._refresh_last_landed_sha(ctx, _common(), pr_number=42)  # noqa: SLF001
+    assert ctx.last_landed_sha == "mergesha"
+
+
+def test_refresh_last_landed_sha_falls_back_to_head(mocker) -> None:  # noqa: ANN001
+    # No PR context (e.g. resume) or the merge commit is unknown: fall back to
+    # origin/<target> HEAD.
+    mocker.patch.object(
+        autoland,
+        "run",
+        return_value=argparse.Namespace(stdout="headsha\n", returncode=0),
+    )
+    mocker.patch.object(autoland.github, "merge_commit", return_value=None)
+    ctx = LandingContext(last_landed_sha="")
+    autoland._refresh_last_landed_sha(ctx, _common(), pr_number=42)  # noqa: SLF001
+    assert ctx.last_landed_sha == "headsha"
+
+
+def test_wait_for_workflow_accepts_run_on_merge_commit(mocker) -> None:  # noqa: ANN001
+    # Regression: a green deploy run on our exact merge commit must satisfy the
+    # checkpoint even though origin/<target> has since moved on.
+    mocker.patch.object(
+        autoland.github,
+        "workflow_runs",
+        return_value=[
+            {"headSha": "mergesha", "status": "completed", "conclusion": "success"}
+        ],
+    )
+    step = WorkflowStep(workflow="deploy.yaml")
+    ctx = LandingContext(last_landed_sha="mergesha")
+    assert autoland.wait_for_workflow(
+        step, opts=_opts(), common=_common(), ctx=ctx
+    )
+    assert step.state == "succeeded"
+
+
+def test_wait_for_workflow_ignores_failed_and_incomplete(mocker) -> None:  # noqa: ANN001
+    # A failed run and a still-running run on our SHA must not satisfy the
+    # checkpoint; abort so the poll loop terminates for the test.
+    calls = {"n": 0}
+
+    def _runs(*_a, **_k) -> list:  # noqa: ANN002, ANN003
+        calls["n"] += 1
+        ctx.aborted = True  # stop after one poll
+        return [
+            {"headSha": "mergesha", "status": "completed", "conclusion": "failure"},
+            {"headSha": "mergesha", "status": "in_progress", "conclusion": None},
+        ]
+
+    mocker.patch.object(autoland.github, "workflow_runs", side_effect=_runs)
+    mocker.patch.object(autoland, "resilient_sleep", return_value=0.0)
+    step = WorkflowStep(workflow="deploy.yaml")
+    ctx = LandingContext(last_landed_sha="mergesha")
+    assert not autoland.wait_for_workflow(
+        step, opts=_opts(), common=_common(), ctx=ctx
+    )
+
+
 # --- plan parsing --------------------------------------------------------
 
 

--- a/tests/test_autoland.py
+++ b/tests/test_autoland.py
@@ -13,10 +13,10 @@ from stack_pr.autoland import (
     AutolandOptions,
     CheckStatus,
     ConfirmStep,
-    DeployStep,
     LandingContext,
     LandStep,
     StackEntry,
+    WorkflowStep,
     evaluate_checks,
     parse_plan,
 )
@@ -28,7 +28,7 @@ def _args(**overrides) -> argparse.Namespace:  # noqa: ANN003
         "poll_interval": None,
         "max_check_retries": None,
         "max_queue_retries": None,
-        "deploy_timeout": None,
+        "workflow_timeout": None,
         "dry_run": False,
         "branch": None,
         "interactive": False,
@@ -166,13 +166,19 @@ def _stack(n: int) -> list:
     ]
 
 
-def test_parse_plan_with_deploy_and_confirm() -> None:
-    text = "l\nd deploy.yaml\nc ship it\nl\n"
+def test_parse_plan_with_workflow_and_confirm() -> None:
+    text = "l\nw deploy.yaml\nc ship it\nl\n"
     steps = parse_plan(text, _stack(2))
-    assert [type(s) for s in steps] == [LandStep, DeployStep, ConfirmStep, LandStep]
+    assert [type(s) for s in steps] == [LandStep, WorkflowStep, ConfirmStep, LandStep]
     assert steps[1].workflow == "deploy.yaml"
     assert steps[2].message == "ship it"
     assert [s.entry_index for s in steps if isinstance(s, LandStep)] == [0, 1]
+
+
+def test_parse_plan_rejects_old_deploy_letter() -> None:
+    # The 'd' letter was renamed to 'w'; it should no longer be recognized.
+    with pytest.raises(ValueError, match="unrecognized step"):
+        parse_plan("l\nd deploy.yaml\n", _stack(1))
 
 
 def test_parse_plan_requires_all_lands() -> None:
@@ -190,7 +196,7 @@ def test_parse_plan_rejects_unknown_step() -> None:
 
 def test_state_round_trip(tmp_path) -> None:  # noqa: ANN001
     ctx = LandingContext(
-        stack=_stack(2), plan=parse_plan("l\nd deploy.yaml\nl\n", _stack(2))
+        stack=_stack(2), plan=parse_plan("l\nw deploy.yaml\nl\n", _stack(2))
     )
     ctx.current_step = 1
     ctx.last_landed_sha = "abc"
@@ -206,7 +212,7 @@ def test_state_round_trip(tmp_path) -> None:  # noqa: ANN001
     assert loaded.last_landed_sha == "abc"
     assert loaded.stack[0].state == autoland.PRState.MERGED
     assert [e.pr_number for e in loaded.stack] == [0, 1]
-    assert [type(s) for s in loaded.plan] == [LandStep, DeployStep, LandStep]
+    assert [type(s) for s in loaded.plan] == [LandStep, WorkflowStep, LandStep]
 
 
 def test_load_state_version_mismatch(tmp_path) -> None:  # noqa: ANN001

--- a/tests/test_autoland.py
+++ b/tests/test_autoland.py
@@ -1,0 +1,216 @@
+import argparse
+import configparser
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+import pytest
+
+from stack_pr import autoland
+from stack_pr.autoland import (
+    AutolandCheckpointer,
+    AutolandOptions,
+    CheckStatus,
+    ConfirmStep,
+    DeployStep,
+    LandingContext,
+    LandStep,
+    StackEntry,
+    evaluate_checks,
+    parse_plan,
+)
+from stack_pr.cli import CommonArgs
+
+
+def _args(**overrides) -> argparse.Namespace:  # noqa: ANN003
+    base = {
+        "poll_interval": None,
+        "max_check_retries": None,
+        "max_queue_retries": None,
+        "deploy_timeout": None,
+        "dry_run": False,
+        "branch": None,
+        "interactive": False,
+        "resume": False,
+        "state_file": None,
+        "always_cleanup": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _common() -> CommonArgs:
+    return CommonArgs(
+        base="main",
+        head="HEAD",
+        remote="origin",
+        target="main",
+        hyperlinks=False,
+        verbose=False,
+        branch_name_template="$USERNAME/stack/$ID",
+        show_tips=False,
+        land_disabled=False,
+    )
+
+
+# --- options -------------------------------------------------------------
+
+
+def test_options_precedence_flag_over_config_over_default() -> None:
+    cfg = configparser.ConfigParser()
+    cfg.add_section("autoland")
+    cfg.set("autoland", "merge_queue", "true")
+    cfg.set("autoland", "poll_interval", "99")
+    cfg.set("autoland", "required_checks", "a, b ,c")
+
+    opts = AutolandOptions.from_config_and_args(
+        cfg, _args(max_check_retries=7)
+    )
+
+    assert opts.merge_queue is True
+    assert opts.poll_interval == 99  # from config
+    assert opts.max_check_retries == 7  # from flag
+    assert opts.max_queue_retries == autoland.DEFAULT_MAX_QUEUE_RETRIES  # default
+    assert opts.required_checks == ["a", "b", "c"]
+
+
+# --- merge-queue gate ----------------------------------------------------
+
+
+def test_run_autoland_requires_merge_queue() -> None:
+    cfg = configparser.ConfigParser()  # no [autoland] -> merge_queue False
+    with pytest.raises(NotImplementedError):
+        autoland.run_autoland(_common(), _args(), cfg)
+
+
+# --- check evaluation (pure: takes the check list) ------------------------
+
+
+def test_evaluate_checks_all_passing_required() -> None:
+    checks = [
+        {"name": "ci", "bucket": "pass"},
+        {"name": "lint", "bucket": "pass"},
+        {"name": "other", "bucket": "fail"},  # not required -> ignored
+    ]
+    assert evaluate_checks(checks, ["ci", "lint"]).status == CheckStatus.ALL_PASSING
+
+
+def test_evaluate_checks_failure_collects_run_id() -> None:
+    checks = [
+        {"name": "ci", "bucket": "pass"},
+        {
+            "name": "lint",
+            "bucket": "fail",
+            "link": "https://github.com/o/r/actions/runs/12345/job/9",
+        },
+    ]
+    res = evaluate_checks(checks, ["ci", "lint"])
+    assert res.status == CheckStatus.FAILED
+    assert res.failed_names == ["lint"]
+    assert res.failed_runs == [12345]
+
+
+def test_evaluate_checks_missing_required_is_not_started() -> None:
+    res = evaluate_checks([{"name": "ci", "bucket": "pass"}], ["ci", "lint"])
+    assert res.status == CheckStatus.NOT_STARTED
+
+
+def test_evaluate_checks_empty_required_gates_on_all() -> None:
+    checks = [
+        {"name": "ci", "bucket": "pass"},
+        {"name": "deploy", "bucket": "skipping"},  # ignored
+        {"name": "lint", "bucket": "pending"},
+    ]
+    assert evaluate_checks(checks, []).status == CheckStatus.PENDING
+
+
+def test_evaluate_checks_empty_required_no_checks() -> None:
+    assert evaluate_checks([], []).status == CheckStatus.NOT_STARTED
+
+
+# --- merge status polling (GitHub.poll_merge) ----------------------------
+
+
+def test_poll_merge_merged(mocker) -> None:  # noqa: ANN001
+    mocker.patch.object(autoland.github, "pr_state", return_value="MERGED")
+    assert autoland.github.poll_merge(1).merged is True
+
+
+def test_poll_merge_closed(mocker) -> None:  # noqa: ANN001
+    mocker.patch.object(autoland.github, "pr_state", return_value="CLOSED")
+    assert autoland.github.poll_merge(1).error == "PR was closed"
+
+
+def test_poll_merge_booted(mocker) -> None:  # noqa: ANN001
+    mocker.patch.object(autoland.github, "pr_state", return_value="OPEN")
+    mocker.patch.object(autoland.github, "in_merge_queue", return_value=False)
+    assert autoland.github.poll_merge(1).booted is True
+
+
+def test_poll_merge_still_queued(mocker) -> None:  # noqa: ANN001
+    mocker.patch.object(autoland.github, "pr_state", return_value="OPEN")
+    mocker.patch.object(autoland.github, "in_merge_queue", return_value=True)
+    res = autoland.github.poll_merge(1)
+    assert not res.merged
+    assert not res.booted
+    assert not res.error
+
+
+# --- plan parsing --------------------------------------------------------
+
+
+def _stack(n: int) -> list:
+    return [
+        StackEntry(pr_url=f"u/{i}", pr_number=i, branch=f"b{i}") for i in range(n)
+    ]
+
+
+def test_parse_plan_with_deploy_and_confirm() -> None:
+    text = "l\nd deploy.yaml\nc ship it\nl\n"
+    steps = parse_plan(text, _stack(2))
+    assert [type(s) for s in steps] == [LandStep, DeployStep, ConfirmStep, LandStep]
+    assert steps[1].workflow == "deploy.yaml"
+    assert steps[2].message == "ship it"
+    assert [s.entry_index for s in steps if isinstance(s, LandStep)] == [0, 1]
+
+
+def test_parse_plan_requires_all_lands() -> None:
+    with pytest.raises(ValueError, match="all PRs must be landed"):
+        parse_plan("l\n", _stack(2))
+
+
+def test_parse_plan_rejects_unknown_step() -> None:
+    with pytest.raises(ValueError, match="unrecognized step"):
+        parse_plan("frobnicate\n", _stack(1))
+
+
+# --- state round-trip ----------------------------------------------------
+
+
+def test_state_round_trip(tmp_path) -> None:  # noqa: ANN001
+    ctx = LandingContext(
+        stack=_stack(2), plan=parse_plan("l\nd deploy.yaml\nl\n", _stack(2))
+    )
+    ctx.current_step = 1
+    ctx.last_landed_sha = "abc"
+    ctx.stack[0].state = autoland.PRState.MERGED  # exercise enum round-trip
+
+    sf = tmp_path / "state.json"
+    AutolandCheckpointer(path=sf, branch="feat", base="main").save(ctx)
+
+    cp, loaded = AutolandCheckpointer.load(sf)
+    assert cp.branch == "feat"
+    assert cp.base == "main"
+    assert loaded.current_step == 1
+    assert loaded.last_landed_sha == "abc"
+    assert loaded.stack[0].state == autoland.PRState.MERGED
+    assert [e.pr_number for e in loaded.stack] == [0, 1]
+    assert [type(s) for s in loaded.plan] == [LandStep, DeployStep, LandStep]
+
+
+def test_load_state_version_mismatch(tmp_path) -> None:  # noqa: ANN001
+    sf = tmp_path / "state.json"
+    sf.write_text('{"version": 999, "stack": [], "plan": [], "branch": "x", "base": "y"}')
+    with pytest.raises(ValueError, match="Unsupported state file version"):
+        AutolandCheckpointer.load(sf)

--- a/tests/test_autoland.py
+++ b/tests/test_autoland.py
@@ -18,6 +18,7 @@ from stack_pr.autoland import (
     StackEntry,
     WorkflowStep,
     evaluate_checks,
+    generate_default_plan,
     parse_plan,
 )
 from stack_pr.cli import CommonArgs
@@ -73,6 +74,23 @@ def test_options_precedence_flag_over_config_over_default() -> None:
     assert opts.max_check_retries == 7  # from flag
     assert opts.max_queue_retries == autoland.DEFAULT_MAX_QUEUE_RETRIES  # default
     assert opts.required_checks == ["a", "b", "c"]
+
+
+def test_default_workflow_from_config() -> None:
+    cfg = configparser.ConfigParser()
+    cfg.add_section("autoland")
+    cfg.set("autoland", "default_workflow", "deploy.yaml")
+    opts = AutolandOptions.from_config_and_args(cfg, _args())
+    assert opts.default_workflow == "deploy.yaml"
+
+
+def test_default_workflow_absent_is_none() -> None:
+    cfg = configparser.ConfigParser()
+    cfg.add_section("autoland")
+    # Empty/whitespace-only value is treated as unset.
+    cfg.set("autoland", "default_workflow", "  ")
+    opts = AutolandOptions.from_config_and_args(cfg, _args())
+    assert opts.default_workflow is None
 
 
 # --- merge-queue gate ----------------------------------------------------
@@ -179,6 +197,15 @@ def test_parse_plan_rejects_old_deploy_letter() -> None:
     # The 'd' letter was renamed to 'w'; it should no longer be recognized.
     with pytest.raises(ValueError, match="unrecognized step"):
         parse_plan("l\nd deploy.yaml\n", _stack(1))
+
+
+def test_generate_default_plan_appends_workflow_when_configured() -> None:
+    plain = generate_default_plan(_stack(2))
+    assert [type(s) for s in plain] == [LandStep, LandStep]
+
+    with_wf = generate_default_plan(_stack(2), default_workflow="deploy.yaml")
+    assert [type(s) for s in with_wf] == [LandStep, LandStep, WorkflowStep]
+    assert with_wf[-1].workflow == "deploy.yaml"
 
 
 def test_parse_plan_requires_all_lands() -> None:

--- a/tests/test_cross_links.py
+++ b/tests/test_cross_links.py
@@ -1,0 +1,110 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from stack_pr import cli
+from stack_pr.cli import (
+    build_stack_pr_list,
+    extract_toc_pr_ids,
+    generate_toc,
+)
+
+
+def _entry(mocker, pr_num: int):  # noqa: ANN001, ANN202
+    e = mocker.Mock()
+    e.pr = f"https://github.com/o/r/pull/{pr_num}"
+    return e
+
+
+def test_extract_toc_pr_ids_bottom_first() -> None:
+    body = "Stacked PRs:\n * __->__#3\n * #2\n * #1\n\n--- --- ---\nbody\n"
+    assert extract_toc_pr_ids(body) == ["1", "2", "3"]
+
+
+def test_extract_toc_pr_ids_requires_table() -> None:
+    # No table at all.
+    assert extract_toc_pr_ids("just a body mentioning #5") == []
+    # Delimiter present but no header -> entries after the delimiter are ignored.
+    assert extract_toc_pr_ids("text\n--- --- ---\n * #5\n") == []
+
+
+def test_generate_toc_suppressed_for_single() -> None:
+    assert generate_toc(["1"], "1") == ""
+    assert generate_toc([], "1") == ""
+
+
+def test_generate_toc_renders_top_first_with_arrow() -> None:
+    toc = generate_toc(["1", "2", "3"], "2")
+    assert toc == "Stacked PRs:\n * #3\n * __->__#2\n * #1\n\n"
+
+
+def test_build_stack_pr_list_keeps_merged(mocker) -> None:  # noqa: ANN001
+    # Active stack is #2, #3 (bottom-first); #1 has landed.
+    st = [_entry(mocker, 2), _entry(mocker, 3)]
+    body = (
+        "Stacked PRs:\n"
+        " * #3\n"
+        " * #2\n"
+        " * #1\n"
+        "\n"
+        "--- --- ---\n"
+        "body text #999\n"  # prose ref after the delimiter must be ignored
+    )
+    mocker.patch("stack_pr.cli.get_pr_body", return_value=body)
+    mocker.patch(
+        "stack_pr.cli.get_pr_state",
+        side_effect=lambda pid: {"1": "MERGED"}.get(pid, "OPEN"),
+    )
+
+    assert build_stack_pr_list(st) == ["1", "2", "3"]
+
+
+def test_build_stack_pr_list_drops_open_absent(mocker) -> None:  # noqa: ANN001
+    # Only #3 is active. #1 merged (keep), #9 left the stack but is still open
+    # (drop).
+    st = [_entry(mocker, 3)]
+    body = "Stacked PRs:\n * #3\n * #9\n * #1\n\n--- --- ---\nx\n"
+    mocker.patch("stack_pr.cli.get_pr_body", return_value=body)
+    mocker.patch(
+        "stack_pr.cli.get_pr_state",
+        side_effect=lambda pid: {"1": "MERGED", "9": "OPEN"}.get(pid, "OPEN"),
+    )
+
+    assert build_stack_pr_list(st) == ["1", "3"]
+
+
+def test_build_stack_pr_list_no_history(mocker) -> None:  # noqa: ANN001
+    # Fresh stack: PR bodies have no cross-links table yet.
+    st = [_entry(mocker, 1), _entry(mocker, 2)]
+    mocker.patch("stack_pr.cli.get_pr_body", return_value="just the commit body")
+    state = mocker.patch("stack_pr.cli.get_pr_state")
+
+    assert build_stack_pr_list(st) == ["1", "2"]
+    state.assert_not_called()
+
+
+def test_build_stack_pr_list_keeps_closed(mocker) -> None:  # noqa: ANN001
+    st = [_entry(mocker, 2)]
+    body = "Stacked PRs:\n * #2\n * #1\n\n--- --- ---\nx\n"
+    mocker.patch("stack_pr.cli.get_pr_body", return_value=body)
+    mocker.patch(
+        "stack_pr.cli.get_pr_state",
+        side_effect=lambda pid: {"1": "CLOSED"}.get(pid, "OPEN"),
+    )
+
+    assert build_stack_pr_list(st) == ["1", "2"]
+
+
+def test_generate_toc_single_active_with_history(mocker) -> None:  # noqa: ANN001
+    # One active PR but merged history -> table still rendered.
+    st = [_entry(mocker, 2)]
+    body = "Stacked PRs:\n * #2\n * #1\n\n--- --- ---\nx\n"
+    mocker.patch("stack_pr.cli.get_pr_body", return_value=body)
+    mocker.patch(
+        "stack_pr.cli.get_pr_state",
+        side_effect=lambda pid: {"1": "MERGED"}.get(pid, "OPEN"),
+    )
+
+    pr_ids = cli.build_stack_pr_list(st)
+    assert generate_toc(pr_ids, "2") == "Stacked PRs:\n * __->__#2\n * #1\n\n"

--- a/tests/test_edit_pr_base.py
+++ b/tests/test_edit_pr_base.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from subprocess import SubprocessError
+
+from stack_pr.cli import edit_pr_base
+
+PR = "https://github.com/o/r/pull/42"
+
+MERGE_QUEUE_ERR = (
+    b"GraphQL: Cannot change the base branch because the branch has been "
+    b"added to a merge queue. (updatePullRequest)"
+)
+
+
+def test_edit_pr_base_success(mocker) -> None:  # noqa: ANN001
+    run = mocker.patch(
+        "stack_pr.cli.run_shell_command",
+        return_value=mocker.Mock(returncode=0, stderr=b""),
+    )
+
+    edit_pr_base(PR, "main", verbose=False)
+
+    run.assert_called_once()
+    assert run.call_args.args[0] == ["gh", "pr", "edit", PR, "-B", "main"]
+
+
+def test_edit_pr_base_merge_queue_skips_without_retry(mocker) -> None:  # noqa: ANN001
+    # No extra_args -> nothing left to apply, so we just warn and move on.
+    run = mocker.patch(
+        "stack_pr.cli.run_shell_command",
+        return_value=mocker.Mock(returncode=1, stderr=MERGE_QUEUE_ERR),
+    )
+    warn = mocker.patch("stack_pr.cli.warning")
+
+    edit_pr_base(PR, "main", verbose=False)
+
+    run.assert_called_once()
+    warn.assert_called_once()
+
+
+def test_edit_pr_base_merge_queue_retries_without_base(mocker) -> None:  # noqa: ANN001
+    # First call (with -B) hits the merge queue; the retry drops -B so the
+    # title/body edits still apply.
+    run = mocker.patch(
+        "stack_pr.cli.run_shell_command",
+        side_effect=[
+            mocker.Mock(returncode=1, stderr=MERGE_QUEUE_ERR),
+            mocker.Mock(returncode=0, stderr=b""),
+        ],
+    )
+    mocker.patch("stack_pr.cli.warning")
+
+    edit_pr_base(
+        PR,
+        "main",
+        extra_args=["-t", "title", "-F", "-"],
+        verbose=False,
+        input=b"body",
+    )
+
+    assert run.call_count == 2
+    first, second = run.call_args_list
+    assert first.args[0] == ["gh", "pr", "edit", PR, "-B", "main", "-t", "title", "-F", "-"]
+    # Retry omits "-B" / "main" but keeps the other edits and the piped body.
+    assert second.args[0] == ["gh", "pr", "edit", PR, "-t", "title", "-F", "-"]
+    assert second.kwargs["input"] == b"body"
+
+
+def test_edit_pr_base_other_error_raises(mocker) -> None:  # noqa: ANN001
+    mocker.patch(
+        "stack_pr.cli.run_shell_command",
+        return_value=mocker.Mock(returncode=1, stderr=b"some other failure"),
+    )
+
+    with pytest.raises(SubprocessError):
+        edit_pr_base(PR, "main", verbose=False)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,55 @@
+import configparser
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+import pytest
+
+from stack_pr import cli
+
+
+def test_install_writes_global_alias(mocker) -> None:  # noqa: ANN001
+    spy = mocker.patch("stack_pr.cli.run_shell_command")
+    cli.command_install("stack", local=False)
+    spy.assert_called_once()
+    cmd = spy.call_args.args[0]
+    assert cmd == ["git", "config", "--global", "alias.stack", "!stack-pr"]
+
+
+def test_install_local_and_custom_name(mocker) -> None:  # noqa: ANN001
+    spy = mocker.patch("stack_pr.cli.run_shell_command")
+    cli.command_install("sp", local=True)
+    cmd = spy.call_args.args[0]
+    assert cmd == ["git", "config", "--local", "alias.sp", "!stack-pr"]
+
+
+def test_help_no_topic_prints_main_help(capsys) -> None:  # noqa: ANN001
+    parser = cli.create_argparser(configparser.ConfigParser())
+    cli.command_help(parser, None)
+    out = capsys.readouterr().out
+    assert "usage:" in out
+    assert "install" in out
+    assert "help" in out
+
+
+def test_help_topic_prints_subcommand_help(capsys) -> None:  # noqa: ANN001
+    parser = cli.create_argparser(configparser.ConfigParser())
+    # argparse prints the subcommand help and exits.
+    with pytest.raises(SystemExit) as exc:
+        cli.command_help(parser, "submit")
+    assert exc.value.code == 0
+    assert "submit" in capsys.readouterr().out
+
+
+def test_install_and_help_args_parse() -> None:
+    parser = cli.create_argparser(configparser.ConfigParser())
+
+    install_args = parser.parse_args(["install", "--name", "sp", "--local"])
+    assert install_args.command == "install"
+    assert install_args.name == "sp"
+    assert install_args.local is True
+
+    help_args = parser.parse_args(["help", "submit"])
+    assert help_args.command == "help"
+    assert help_args.topic == "submit"


### PR DESCRIPTION
## Problem

In a busy repo, an `autoland` workflow checkpoint (`w <workflow>`) can poll forever even after the target workflow run completes successfully.

Observed in `openevidence/xyla`: PR #20199 merged as commit `7897d271`, the deploy workflow ran green on that commit — but autoland kept waiting on target SHA `bf793554`, an automated config-bump commit (#20214) that landed ~12 min *later*.

## Root cause

`_refresh_last_landed_sha` set the checkpoint target to the current `origin/<target>` HEAD via `git rev-parse`. Between the PR merging and that call, `origin/<target>` can advance past the landed PR's merge commit (bot commits, other PRs).

The checkpoint accepts a run whose head SHA equals the target *or* has the target as an ancestor. When the target overshoots to a descendant of the real merge commit, the green run on the merge commit is rejected (`_is_ancestor(overshot_target, merge_commit)` is false), so it polls indefinitely.

## Fix

Capture the landed PR's exact merge commit (`gh pr view --json mergeCommit`) and use it as the checkpoint target. Fall back to `origin/<target>` HEAD only when there's no PR context (e.g. resume without a preceding land step).

## Tests

Added coverage for `GitHub.merge_commit`, `_refresh_last_landed_sha` (prefers merge commit, falls back to HEAD), and `wait_for_workflow` (accepts a run on the merge commit; ignores failed/incomplete runs). Full suite: 68 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)